### PR TITLE
1.0.0.5

### DIFF
--- a/Hyperborea/Gui/EditorWindow.cs
+++ b/Hyperborea/Gui/EditorWindow.cs
@@ -192,7 +192,11 @@ public class EditorWindow : Window
                     if(ImGui.Button("Reset"))
                     {
                         Utils.LoadBuiltInZoneData();
-                        new TickScheduler(() => P.ZoneData.Data.Remove(bg));
+                        new TickScheduler(() =>
+                        {
+                            P.ZoneData.Data.Remove(bg);
+                            P.SaveZoneData();
+                        });
                     }
                 }
             }

--- a/Hyperborea/Hyperborea.csproj
+++ b/Hyperborea/Hyperborea.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <Authors>kawaii</Authors>
-        <Version>1.0.0.4</Version>
+        <Version>1.0.0.5</Version>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/Hyperborea/data.yaml
+++ b/Hyperborea/data.yaml
@@ -1,23 +1,23 @@
 Data:
   ffxiv/fst_f1/bah/f1bz/level/f1bz:
-    Name: the Unending Coil of Bahamut (Ultimate)
+    Name: The Unending Coil of Bahamut (Ultimate)
     Spawn:
       X: 0
       Y: 0
       Z: 0
     Phases:
-    - Name: Phase 1
+    - Name: Twintania
       Weather: 2
       MapEffects: []
-    - Name: Phase 2
+    - Name: Nael Van Darnus
       Weather: 21
       MapEffects: []
-    - Name: Phase 3
+    - Name: Bahamut Prime
       Weather: 30
       MapEffects: []
-    - Name: Phase 4
+    - Name: Triple Threat
       Weather: 31
       MapEffects: []
-    - Name: Phase 5
+    - Name: Golden Bahamut
       Weather: 32
       MapEffects: []  


### PR DESCRIPTION
- fixes an issue where overrides created with the zone editor could not be reset to default
- updated the default phase names for UCOB to be more descriptive