### PR TITLE
Fetch Global Scale in safe manner

### DIFF
--- a/Hyperborea/Hyperborea.cs
+++ b/Hyperborea/Hyperborea.cs
@@ -59,8 +59,8 @@ public unsafe class Hyperborea : IDalamudPlugin
             EzConfig.DefaultSerializationFactory = YamlFactory;
             var scale = ImGui.GetIO().FontGlobalScale;
             var constraint = new Window.WindowSizeConstraints() { MinimumSize = new(300f * scale, 100f), MaximumSize = new(300f * scale, 1000f) };
-            constraint.MaximumSize /= ImGuiHelpers.GlobalScale;
-            constraint.MinimumSize /= ImGuiHelpers.GlobalScale;
+            constraint.MaximumSize /= ImGuiHelpers.GlobalScaleSafe;
+            constraint.MinimumSize /= ImGuiHelpers.GlobalScaleSafe;
             Config = EzConfig.Init<Config>();
             EzConfigGui.Init(UI.DrawNeo);
             EzConfigGui.Window.SizeConstraints = constraint;


### PR DESCRIPTION
Turns out using ImGuiHelpers.GlobalScale at this point sometimes spits out 0 (when it's fetched before drawing is actually ready?) thus resulting in dividing constraints by 0 which then destroys the Hyperborea window completely and requires plugin reload.

Example of an instance when GlobalScale returned 0 making it unsafe to use.

![Screenshot 2025-02-21 223322](https://github.com/user-attachments/assets/48eecbb0-fec0-47b1-8c32-8d5760b4e87a)
![Screenshot 2025-02-21 223258](https://github.com/user-attachments/assets/bee1aa69-7caf-46b3-9ec4-6ca4c4a8a2f0)