### PR TITLE
Replace MapEffects with a correct(er?) version (maybe? idk)

### DIFF
--- a/Hyperborea/Gui/EditorWindow.cs
+++ b/Hyperborea/Gui/EditorWindow.cs
@@ -1,4 +1,4 @@
-﻿using Dalamud.Interface.Components;
+using Dalamud.Interface.Components;
 using Dalamud.Interface.Utility.Raii;
 using ECommons.Configuration;
 using ECommons.ExcelServices;
@@ -168,23 +168,96 @@ public unsafe class EditorWindow : Window
                             Safe(() => p.MapEffects = P.YamlFactory.Deserialize<List<MapEffectInfo>>(Paste()));
                         }
                         ImGuiEx.Tooltip("Paste and override MapEffects into this phase.");
+                        var slots = MapEffectResolver.GetZoneSlots(TerrID);
                         foreach (var x in p.MapEffects)
                         {
                             ImGui.PushID(x.GUID);
-                            ImGui.SetNextItemWidth(100f);
-                            ImGui.InputInt($"##a1", ref x.a1);
+
+                            var isDupe = p.MapEffects.Count(y => y.Slot == x.Slot) > 1;
+                            if (isDupe)
+                            {
+                                ImGuiEx.Text(EColor.RedBright, "[DUPLICATE SLOT]");
+                                ImGuiEx.Tooltip("Another entry in this phase already targets this slot. Only the last one in the list will actually apply.");
+                                ImGui.SameLine();
+                            }
+
+                            var curSlot = slots.FirstOrDefault(s => s.Slot == x.Slot);
+                            ImGui.SetNextItemWidth(180f);
+                            if (ImGui.BeginCombo("##slot", curSlot != null ? $"{x.Slot}: {curSlot.SgbName}" : $"Slot {x.Slot} (unknown)"))
+                            {
+                                foreach (var s in slots)
+                                {
+                                    if (s.Slot != x.Slot && p.MapEffects.Any(y => y.GUID != x.GUID && y.Slot == s.Slot)) continue;
+
+                                    if (ImGui.Selectable($"{s.Slot}: {s.SgbName}##slot{s.Slot}", x.Slot == s.Slot))
+                                    {
+                                        x.Slot = s.Slot;
+                                        x.State = 0;
+                                        x.TimelineOverride = 0;
+                                    }
+                                }
+                                ImGui.EndCombo();
+                            }
+                            ImGuiEx.Tooltip("Which MapEffect slot to control.");
                             ImGui.SameLine();
-                            ImGui.SetNextItemWidth(100f);
-                            ImGui.InputInt($"##a2", ref x.a2);
+
+                            var states = curSlot?.States ?? [];
+                            var curStateName = states.FirstOrDefault(st => st.State == (ushort)x.State).Name;
+                            ImGui.SetNextItemWidth(180f);
+                            if (ImGui.BeginCombo("##state", curStateName.NullWhenEmpty() != null ? $"{x.State}: {curStateName}" : $"State {x.State}"))
+                            {
+                                if (ImGui.Selectable("0 (no-op)", x.State == 0)) x.State = 0;
+                                foreach (var (state, name) in states)
+                                {
+                                    if (ImGui.Selectable($"{state}: {name}##st{state}", x.State == state)) x.State = state;
+                                }
+                                ImGui.EndCombo();
+                            }
+                            ImGuiEx.Tooltip("Which state to set the slot to. By default this also drives which timeline actively plays.");
                             ImGui.SameLine();
-                            ImGui.SetNextItemWidth(100f);
-                            ImGui.InputInt($"##a3", ref x.a3);
+
+                            if (ImGuiEx.IconButton(FontAwesomeIcon.Cog))
+                            {
+                                ImGui.SetNextWindowPos(new Vector2(ImGui.GetItemRectMin().X, ImGui.GetItemRectMax().Y));
+                                ImGui.OpenPopup("##advTimeline");
+                            }
+                            ImGuiEx.Tooltip("Advanced: override which timelines actively play, independent of State.\nLeave at default (0) unless you need to combine multiple independent effects on this slot (e.g. torches + gate) or trigger a transition bit that isn't a resting State value.");
+                            ImGui.SetNextWindowSize(new Vector2(280f, 0f), ImGuiCond.Appearing);
+                            if (ImGui.BeginPopup("##advTimeline"))
+                            {
+                                ImGui.PushTextWrapPos(ImGui.GetCursorPosX() + 260f);
+                                ImGuiEx.TextWrapped("Which timelines actively play/stop right now. Leave everything unchecked to just follow State above (default, safest).");
+                                ImGui.PopTextWrapPos();
+                                if (ImGui.Selectable("Reset to default (follow State)")) x.TimelineOverride = 0;
+                                ImGui.Separator();
+                                foreach (var (state, name) in states)
+                                {
+                                    var on = ((ushort)x.TimelineOverride & state) != 0;
+                                    if (ImGui.Checkbox($"{state}: {name}##tl{state}", ref on))
+                                    {
+                                        x.TimelineOverride = on ? (x.TimelineOverride | state) : (x.TimelineOverride & ~state);
+                                    }
+                                }
+                                ImGui.EndPopup();
+                            }
+                            if (x.TimelineOverride != 0)
+                            {
+                                ImGui.SameLine();
+                                var curTimelineNames = states.Where(st => ((ushort)x.TimelineOverride & st.State) != 0).Select(st => st.Name).ToList();
+                                ImGuiEx.Text(EColor.YellowBright, curTimelineNames.Count > 0 ? string.Join(", ", curTimelineNames) : $"{x.TimelineOverride}");
+                                ImGuiEx.Tooltip("Timeline override active (not following State).");
+                            }
                             ImGui.SameLine();
+
                             if (ImGui.Button("Delete"))
                             {
                                 new TickScheduler(() => p.MapEffects.RemoveAll(z => z.GUID == x.GUID));
                             }
                             ImGui.PopID();
+                        }
+                        if (slots.Count == 0)
+                        {
+                            ImGui.TextDisabled(" No MapEffect slots found for this zone.");
                         }
                         ImGuiEx.TextV($"Festivals:");
                         var zoneFests = Utils.GetZoneFestivals(bg);

--- a/Hyperborea/Hyperborea.csproj
+++ b/Hyperborea/Hyperborea.csproj
@@ -72,6 +72,10 @@
             <HintPath>$(DalamudLibPath)FFXIVClientStructs.dll</HintPath>
             <Private>False</Private>
         </Reference>
+		<Reference Include="InteropGenerator.Runtime">
+            <HintPath>$(DalamudLibPath)InteropGenerator.Runtime.dll</HintPath>
+            <Private>False</Private>
+        </Reference>
         <Reference Include="ImGuiScene">
             <HintPath>$(DalamudLibPath)ImGuiScene.dll</HintPath>
             <Private>False</Private>

--- a/Hyperborea/LvbFile.cs
+++ b/Hyperborea/LvbFile.cs
@@ -2,6 +2,7 @@
 
 namespace Hyperborea;
 
+// TODO: This should be removed once Lumina LvbFile got merged! See Utils.cs comment on ParseLvb
 unsafe public class LvbFile : FileResource
 {
     public ushort[] weatherIds;

--- a/Hyperborea/MapEffectResolver.cs
+++ b/Hyperborea/MapEffectResolver.cs
@@ -1,0 +1,200 @@
+using Lumina.Data;
+using Lumina.Data.Files;
+using Lumina.Data.Parsing.Layer;
+using Lumina.Excel.Sheets;
+using System.IO;
+
+namespace Hyperborea;
+
+public sealed class MapEffectSlotInfo
+{
+    public ushort Slot;
+    public uint LayoutId;
+    public bool DefaultOn;
+    public string SgbPath = "";
+    public (ushort State, string Name)[] States = [];
+
+    public string SgbName => string.IsNullOrEmpty(SgbPath)
+        ? $"#{LayoutId:X8}"
+        : Path.GetFileNameWithoutExtension(SgbPath);
+}
+
+public static class MapEffectResolver
+{
+    private static readonly string[] LgbNames = ["bg", "planmap", "planevent", "planlive", "vfx", "sound", "planner"];
+
+    private static Dictionary<uint, ushort>? _cfcToManagedSGRow;
+    private static readonly Dictionary<uint, List<MapEffectSlotInfo>> _zoneCache = [];
+
+    public static List<MapEffectSlotInfo> GetZoneSlots(uint territoryType)
+    {
+        if (_zoneCache.TryGetValue(territoryType, out var cached)) return cached;
+
+        var result = new List<MapEffectSlotInfo>();
+        _zoneCache[territoryType] = result;
+
+        var territory = Svc.Data.GetExcelSheet<TerritoryType>()?.GetRowOrDefault(territoryType);
+        if (territory == null) return result;
+
+        var cfcId = territory.Value.ContentFinderCondition.RowId;
+        if (cfcId == 0) return result;
+
+        EnsureCfcMap();
+        if (!_cfcToManagedSGRow!.TryGetValue(cfcId, out var sgRowId)) return result;
+
+        var sgSheet = Svc.Data.GetSubrowExcelSheet<ContentDirectorManagedSG>();
+        var subrows = sgSheet?.GetRowOrDefault(sgRowId);
+        if (subrows == null) return result;
+
+        ushort slotIdx = 0;
+        foreach (var sub in subrows.Value)
+        {
+            var slot = slotIdx++;
+            if (sub.LayoutId == 0) continue;
+            result.Add(new MapEffectSlotInfo
+            {
+                Slot = slot,
+                LayoutId = (uint)sub.LayoutId,
+                DefaultOn = sub.Unknown1,
+            });
+        }
+        if (result.Count == 0) return result;
+
+        var bg = territory.Value.Bg.ExtractText();
+        ResolveSgbPaths(bg, result);
+
+        foreach (var s in result)
+        {
+            if (string.IsNullOrEmpty(s.SgbPath)) continue;
+            s.States = ReadStateMappings(s.SgbPath);
+        }
+
+        return result;
+    }
+
+    public static void InvalidateCache(uint? territoryType = null)
+    {
+        if (territoryType.HasValue) _zoneCache.Remove(territoryType.Value);
+        else _zoneCache.Clear();
+    }
+
+    private static void EnsureCfcMap()
+    {
+        if (_cfcToManagedSGRow != null) return;
+        _cfcToManagedSGRow = [];
+        var sheet = Svc.Data.GetExcelSheet<InstanceContent>();
+        if (sheet == null) return;
+        foreach (var row in sheet)
+        {
+            var cfc = row.ContentFinderCondition.RowId;
+            var sg = row.ContentDirectorManagedSG.RowId;
+            if (cfc == 0 || sg == 0) continue;
+            _cfcToManagedSGRow.TryAdd(cfc, (ushort)sg);
+        }
+    }
+
+    private static void ResolveSgbPaths(string bg, List<MapEffectSlotInfo> slots)
+    {
+        if (string.IsNullOrEmpty(bg)) return;
+        var slash = bg.LastIndexOf('/');
+        var dir = slash >= 0 ? bg[..slash] : bg;
+
+        var wanted = new Dictionary<uint, MapEffectSlotInfo>();
+        foreach (var s in slots) wanted.TryAdd(s.LayoutId, s);
+        if (wanted.Count == 0) return;
+
+        foreach (var name in LgbNames)
+        {
+            if (wanted.Count == 0) break;
+
+            LgbFile? lgb;
+            try { lgb = Svc.Data.GetFile<LgbFile>($"bg/{dir}/{name}.lgb"); }
+            catch { continue; }
+            if (lgb == null) continue;
+
+            foreach (var layer in lgb.Layers)
+            {
+                if (wanted.Count == 0) break;
+                foreach (var io in layer.InstanceObjects)
+                {
+                    if (io.AssetType != LayerEntryType.SharedGroup) continue;
+                    if (!wanted.TryGetValue(io.InstanceId, out var slot)) continue;
+                    if (io.Object is LayerCommon.SharedGroupInstanceObject sg)
+                    {
+                        slot.SgbPath = sg.AssetPath;
+                        wanted.Remove(io.InstanceId);
+                    }
+                }
+            }
+        }
+    }
+
+
+	// TODO: This should be changed to the proper SGBFile in Lumina once it got merged!
+	// return Svc.Data.GetFile<SgbFile>(sgbPath)?.StateMappings
+    private static (ushort State, string Name)[] ReadStateMappings(string sgbPath)
+    {
+        byte[]? data;
+        try { data = Svc.Data.GetFile<FileResource>(sgbPath)?.Data; }
+        catch { return []; }
+        if (data == null || data.Length < 60) return [];
+
+        var offsetAnimHandlers = BitConverter.ToInt32(data, 52);
+        if (offsetAnimHandlers <= 0) return []; 
+        var configBase = 20 + offsetAnimHandlers;
+        if (configBase + 21 > data.Length) return [];
+
+        var offsetTimelines = BitConverter.ToInt32(data, 36);
+        var fileDataBase = 20 + offsetTimelines;
+        if (fileDataBase + 8 > data.Length) return [];
+
+        var entryOffset = BitConverter.ToInt32(data, fileDataBase);
+        var count = BitConverter.ToInt32(data, fileDataBase + 4);
+        if (count <= 0 || count > 128) return [];
+
+        var tmlbNames = ExtractTmlbNames(data, count);
+
+        var subIdToName = new Dictionary<int, string>(count);
+        for (var n = 0; n < count; n++)
+        {
+            var entryStart = fileDataBase + entryOffset + n * 44;
+            if (entryStart + 4 > data.Length) break;
+            var subId = BitConverter.ToInt32(data, entryStart);
+            if (subId > 0 && n < tmlbNames.Length)
+                subIdToName.TryAdd(subId, tmlbNames[n]);
+        }
+
+        var result = new List<(ushort, string)>(16);
+        for (var i = 0; i < 16; i++)
+        {
+            int subId = data[configBase + 5 + i];
+            if (subId == 0) continue;
+            var state = (ushort)(1 << i);
+            var name = subIdToName.TryGetValue(subId, out var n2) ? n2 : $"SubId={subId}";
+            result.Add((state, name));
+        }
+        return [.. result];
+    }
+
+    private static string[] ExtractTmlbNames(byte[] data, int limit)
+    {
+        var markerPos = -1;
+        for (var i = data.Length - 1; i >= 0; i--)
+        {
+            if (data[i] == 0xFF) { markerPos = i; break; }
+        }
+        if (markerPos < 0 || markerPos >= data.Length - 1) return [];
+
+        var names = new List<string>(limit);
+        var pos = markerPos + 1;
+        while (pos < data.Length && names.Count < limit)
+        {
+            var start = pos;
+            while (pos < data.Length && data[pos] != 0) pos++;
+            if (pos > start)
+                names.Add(Encoding.UTF8.GetString(data, start, pos - start));
+            pos++;
+        }
+        return [.. names];
+    }
+}

--- a/Hyperborea/Utils.cs
+++ b/Hyperborea/Utils.cs
@@ -165,7 +165,8 @@ public unsafe static class Utils
         {
             foreach(var x in phase.MapEffects)
             {
-                MapEffect.Delegate(Utils.GetMapEffectModule(), (uint)x.a1, (ushort)x.a2, (ushort)x.a3);
+                var timelineIndex = x.TimelineOverride != 0 ? x.TimelineOverride : x.State;
+                MapEffect.Delegate(GetMapEffectModule(), (uint)x.Slot, (ushort)x.State, (ushort)timelineIndex);
             }
         }
         P.ApplyFestivals(phase.Festivals);
@@ -209,6 +210,13 @@ public unsafe static class Utils
         return false;
     }
 
+    // TODO: This should be changed to the Lumina LvbFile once it got merged!
+    // var file = Svc.Data.GetFile<Lumina.Data.Files.LvbFile>($"bg/{territoryType.Value.Bg}.lvb");
+    // if (file?.WeatherIds == null || file.WeatherIds.Length == 0) return (null, null);
+    // foreach (var weather in file.WeatherIds) if (weather > 0 && weather < 255) weathers.Add((byte)weather);
+    // weathers.Sort();
+    // return (weathers, file.EnvbFile);
+    // (and delete Hyperborea's own LvbFile.cs entirely)
     public static (List<byte> WeatherList, string EnvbFile) ParseLvb(ushort id)
     {
         var weathers = new List<byte>();

--- a/Hyperborea/ZoneInfo.cs
+++ b/Hyperborea/ZoneInfo.cs
@@ -22,9 +22,9 @@ public class PhaseInfo
 public class MapEffectInfo
 {
     [NonSerialized] internal string GUID = Guid.NewGuid().ToString();
-    public int a1;
-    public int a2;
-    public int a3;
+    public int Slot; 
+    public int State; 
+    public int TimelineOverride;
 }
 
 [Serializable]

--- a/Hyperborea/data.yaml
+++ b/Hyperborea/data.yaml
@@ -1,23 +1,21652 @@
 Data:
-  ffxiv/fst_f1/bah/f1bz/level/f1bz:
-    Name: The Unending Coil of Bahamut (Ultimate)
+  ex1/01_roc_r2/dun/r2d3/level/r2d3:
+    Name: Xelphatol
     Spawn:
       X: 0
       Y: 0
       Z: 0
-    Phases:
-    - Name: Twintania
-      Weather: 2
-      MapEffects: []
-    - Name: Nael Van Darnus
-      Weather: 21
-      MapEffects: []
-    - Name: Bahamut Prime
-      Weather: 30
-      MapEffects: []
-    - Name: Triple Threat
-      Weather: 31
-      MapEffects: []
-    - Name: Golden Bahamut
-      Weather: 32
-      MapEffects: []  
+    MapEffects:
+      sgbg_r2d3_v1_rid11:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_r2d3_v1_rid12:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+  ex1/02_dra_d2/alx/d2az/level/d2az:
+    Name: the Epic of Alexander (Ultimate)
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgvf_d2az_b1724:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+      sgbg_d2az_p3_bos00:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+      sgbg_d2a0_ac_alx00:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_d2az_p4_sky0:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 32768
+          name: ''
+      sgbg_d2az_p4_boss0:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+      sgbg_d2az_al_alx00:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_d2az_b1745:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+  ex1/02_dra_d2/dun/d2d2/level/d2d2:
+    Name: the Aery
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgvf_d2d2_b2559:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+  ex1/02_dra_d2/dun/d2d6/level/d2d6:
+    Name: Sohr Khai
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_d2d6_b0_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+  ex1/03_abr_a2/dun/a2d2/level/a2d2:
+    Name: Neverreap
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_a2d2_a3_all11:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+  ex2/01_gyr_g3/dun/g3d1/level/g3d1:
+    Name: Castrum Abania
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_g3d1_a0_door3:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+  ex2/01_gyr_g3/dun/g3d2/level/g3d2:
+    Name: Ala Mhigo
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_g3d2_a0_gmc02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_g3d2_a0_gmc11:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_g3d2_a0_gmc07:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+  ex2/02_est_e3/dun/e3d2/level/e3d2:
+    Name: A Hunter True
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgvf_e3d2_b3140:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+  ex2/02_est_e3/dun/e3d3/level/e3d3:
+    Name: Doma Castle
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_e3d3_s1_sht1a:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_e3d3_d3_gmc09:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_e3d3_d3_rub1a:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_e3d3_d3_gmc13:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_e3d3_d3_gmc11:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+  ex2/05_zon_z3/ome/z3oy/level/z3oy:
+    Name: Dancing Mad (Ultimate)
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_z3oy_a0_gmc19:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+      sgvf_z3oy_b3793:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_z3oy_b3794:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_z3oy_a0_gmc08:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_z3oy_a9_gmc08:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 4
+          name: ''
+      sgvf_z3oy_b4256:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_z3oy_a7_flo2a:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+      sgbg_z3oy_a7_flo2f:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+      sgbg_z3oy_a7_flo2b:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+      sgbg_z3oy_a7_flo2e:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+      sgbg_z3oy_a7_flo2d:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+      sgbg_z3oy_a7_flo2c:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+      sgbg_z3oy_a7_flo2h:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+      sgbg_z3oy_a7_flo2i:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+      sgbg_z3oy_a7_flo2g:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+      sgbg_z3oy_a7_grk2a:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgbg_z3oy_a7_grk1e:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgvf_z3oy_b4254:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_z3oy_a8_pan00:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+  ex2/05_zon_z3/ome/z3oz/level/z3oz:
+    Name: the Omega Protocol (Ultimate)
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_z3oz_p0_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_z3oz_p0_gmc05:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+        - id: 8192
+          name: ''
+      sgvf_z3oz_b2744:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+      sgvf_z3of_b1477:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 32
+          name: ''
+        - id: 128
+          name: ''
+      sgvf_z3of_b1471:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_z3oz_p0_gmc10:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_z3oz_p0_gmc11:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_z3oz_p0_gmc08:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_z3oz_b2646:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+  ex3/01_nvt_n4/btl/n4b2/level/n4b2:
+    Name: the Bozja Incident
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_n4b2_a0_gmc03:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_n4b2_a0_gmc04:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_n4b2_a0_gmc05:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_n4b2_a0_gmc15:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_n4b2_a0_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_n4b2_a0_gmc02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_n4b2_a0_gmc12:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+      sgvf_n4b2_b1915:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_n4b2_b1918:
+        Description: ''
+        States:
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_n4b2_b1919:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+  ex3/01_nvt_n4/btl/n4b3/level/n4b3:
+    Name: A Sleep Disturbed
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgvf_n4b3_b1851:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+      sgvf_n4b3_b1848:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+      sgvf_n4b3_b1850:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+      sgvf_n4b3_b1849:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+      sgvf_n4b3_b1769:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+  ex3/01_nvt_n4/dun/n4d1/level/n4d1:
+    Name: Holminster Switch
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_n4d1_a2_gmc15:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 16
+          name: ''
+      sgbg_n4d1_a2_gmc03:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_n4d1_a3_gmc07:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_n4d1_a3_gmc09:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_n4d1_a3_gmc14:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+  ex3/01_nvt_n4/dun/n4d2/level/n4d2:
+    Name: Dohn Mheg
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_n4d2_a1_gmc03:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_n4d2_a2_gmc07:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_n4d2_a2_gmc04:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+  ex3/01_nvt_n4/dun/n4d3/level/n4d3:
+    Name: the Qitana Ravel
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_n4d3_a1_gmc02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_n4d3_a1_gmc03:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_n4d3_a3_gmc15:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_n4d3_a3_gmc16:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgvf_n4d3_b1584:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+  ex3/01_nvt_n4/dun/n4d4/level/n4d4:
+    Name: Malikah's Well
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_n4d4_a3_gmc07:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_n4d4_a3_gmc08:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_n4d4_a3_gmc09:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+  ex3/01_nvt_n4/dun/n4d5/level/n4d5:
+    Name: Mt. Gulg
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_n4d5_a1_gmc05:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_n4d5_a1_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_n4d5_a1_gmc03:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_n4d5_a2_gmc06:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_n4d5_a2_gmc17:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+      sgbg_n4d5_a3_gmc09:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_n4d5_a2_gmc18:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+  ex3/01_nvt_n4/dun/n4d6/level/n4d6:
+    Name: Amaurot
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_n4d6_a1_gmc09:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgbg_n4d6_a1_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_n4d6_a1_gmc15:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_n4d6_a2_gmc14:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_n4d6_a2_gmc04:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_n4d6_a2_gmc05:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+  ex3/01_nvt_n4/dun/n4d7/level/n4d7:
+    Name: the Twinning
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_n4d7_a1_gmc02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 16
+          name: ''
+      sgbg_n4d7_a3_gmc07:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_n4d7_a3_gmc12:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+  ex3/01_nvt_n4/dun/n4d8/level/n4d8:
+    Name: Akadaemia Anyder
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_n4d8_a1_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_n4d8_a2_gmc04:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgvf_n4d8_b1702:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+  ex3/01_nvt_n4/dun/n4d9/level/n4d9:
+    Name: the Grand Cosmos
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_n4d9_a1_gmc06:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_n4d9_a1_gmc02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_n4d9_a1_gmc04:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_n4d9_a2_gmc08:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_n4d9_a2_gmc09:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_n4d9_a3_gmc11:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_n4d9_a3_gmc12:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_n4d9_a2_gmc20:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+      sgbg_n4d9_a3_gmc23:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+      sgbg_n4d9_a3_gmc24:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+      sgbg_n4d9_a3_gmc25:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+      sgbg_n4d9_a3_gmc26:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+      sgbg_n4d9_a3_gmc22:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+  ex3/01_nvt_n4/dun/n4da/level/n4da:
+    Name: Anamnesis Anyder
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_n4da_a1_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+      sgbg_n4da_b1_bis01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 16384
+          name: ''
+        - id: 32768
+          name: ''
+      sgvf_n4da_b1753:
+        Description: ''
+        States:
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_n4da_a2_gmc08:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+      sgbg_n4da_a2_gmc09:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+      sgbg_n4da_a3_gmc10:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+      sgbg_n4da_a2_gmc11:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_n4da_a2_gmc13:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+        - id: 8192
+          name: ''
+      sgbg_n4da_a3_gmc15:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+      sgvf_n4da_b1912:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_n4da_b1913:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+  ex3/01_nvt_n4/dun/n4db/level/n4db:
+    Name: the Heroes' Gauntlet
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_n4db_a1_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_n4db_a1_gmc03:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_n4db_a2_gmc06:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_n4db_a2_gmc08:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_n4db_a2_gmc10:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_n4db_a3_gmc12:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_n4db_a3_gmc14:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgvf_n4db_b1857:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_n4db_b1951:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+  ex3/01_nvt_n4/evt/n4e9/level/n4e9:
+    Name: As the Heart Bids
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgvf_n4e9_b1699:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgvf_n4e9_b1813:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_n4e9_a0_win01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 4
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+        - id: 8192
+          name: ''
+        - id: 16384
+          name: ''
+        - id: 32768
+          name: ''
+  ex3/01_nvt_n4/fld/n4fa/level/n4fa:
+    Name: Special Event II
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_n4fa_t1_tre01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+  ex3/01_nvt_n4/fld/n4fe/level/n4fe:
+    Name: Cinder Drift
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgvf_n4fe_b1824:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+      sgbg_n4fe_d2_mete1:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+      sgvf_n4fe_b1926:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgvf_n4fe_b1831:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgvf_n4fe_b1903:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_n4fe_b0_dala02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+      sgvf_n4fe_b1833:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgvf_n4fe_b1823:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_n4fe_b1822:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+  ex3/01_nvt_n4/fld/n4ff/level/n4ff:
+    Name: the Seat of Sacrifice
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgvf_w_lvd_b2007:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+      sgbg_n4ff_d1_gmc010:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_n4ff_d1_sword01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+        - id: 8192
+          name: ''
+      sgbg_n4ff_d1_floor01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_n4ff_b1863:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_n4ff_b1876:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+      sgvf_n4ff_b1877:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+  ex3/01_nvt_n4/fld/n4fg/level/n4fg:
+    Name: Castrum Marinum
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_n4fg_a1_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+      sgvf_n4fg_b2060:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_w_cut_520_01a:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+      sgvf_n4fg_b2081:
+        Description: ''
+        States:
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_n4fg_b2080:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 4
+          name: ''
+  ex3/01_nvt_n4/fld/n4fh/level/n4fh:
+    Name: the Cloud Deck
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_n4fh_a0_gsv2g:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_n4fh_a0_gsv1g:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+      sgbg_n4fh_a0_gsv3:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgbg_n4fh_a0_warp2:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 32
+          name: ''
+      sgvf_n4fh_b1767:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_n4fh_b1793:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_n4fh_b1782:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_n4fh_b1774:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+      sgvf_n4fh_b1775:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgvf_n4fh_b1779:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 4
+          name: ''
+  ex3/01_nvt_n4/goe/n4g5/level/n4g5:
+    Name: "Eden's Verse: Fulmination"
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_n4g5_a0_yari2:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgbg_n4g5_a1_yari2:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+      sgbg_n4g5_a0_yari1:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_n4g5_a2_tou01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_n4g5_a3_yari2:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 32
+          name: ''
+      sgvf_w_lvd_b1472:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+  ex3/01_nvt_n4/goe/n4g6/level/n4g6:
+    Name: "Eden's Verse: Furor"
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgvf_n4g6_b1835:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+      sgbg_n4g6_a0_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+  ex3/01_nvt_n4/goe/n4g7/level/n4g7:
+    Name: "Eden's Verse: Iconoclasm"
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgvf_n4g7_b1759:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+      sgvf_n4g7_b1761:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgbg_n4g7_a0_crwd1:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+      sgvf_w_btl_b1923:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgvf_w_btl_b1922:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+  ex3/01_nvt_n4/goe/n4g8/level/n4g8:
+    Name: "Eden's Verse: Refulgence"
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_n4g8_a1_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+      sgbg_n4g8_a1_gmc02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_n4g8_a1_gmc12:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+      sgbg_n4g8_a1_gmc13:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+      sgbg_n4g8_a1_gmc14:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+      sgbg_n4g8_a1_gmc15:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+      sgbg_n4g8_a1_gmc05:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+        - id: 8192
+          name: ''
+        - id: 16384
+          name: ''
+        - id: 32768
+          name: ''
+      sgbg_n4g8_a1_gmc16:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+      sgvf_n4g8_b1932:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_w_lvd_b1844:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+      sgvf_w_lvd_b1845:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+      sgvf_w_lvd_b1846:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+        - id: 8192
+          name: ''
+        - id: 16384
+          name: ''
+      sgvf_w_lvd_b1843:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+  ex3/01_nvt_n4/goe/n4g9/level/n4g9:
+    Name: "Eden's Promise: Umbra"
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_n4g9_a0_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+        - id: 8192
+          name: ''
+        - id: 16384
+          name: ''
+      sgbg_n4g9_a3_gmc04:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 512
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 8192
+          name: ''
+      sgvf_n4g9_b2160:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+      sgvf_w_btl_b2162:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_w_btl_b1879:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+      sgbg_n4g9_a2_gmc02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+  ex3/01_nvt_n4/goe/n4ga/level/n4ga:
+    Name: "Eden's Promise: Litany"
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgvf_n4ga_b1971:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+        - id: 8192
+          name: ''
+        - id: 16384
+          name: ''
+        - id: 32768
+          name: ''
+      sgvf_n4ga_b1972:
+        Description: ''
+        States:
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgvf_n4ga_b1970:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 2048
+          name: ''
+      sgvf_n4ga_b1973:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+  ex3/01_nvt_n4/goe/n4gc/level/n4gc:
+    Name: "Eden's Promise: Eternity"
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_n4gc_a1_gmc06:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_n4gc_a1_gmc08:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_n4gc_a1_gmc09:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_n4gc_a1_gmc10:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_n4gc_a1_gmc11:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_n4gc_a1_gmc12:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_n4gc_a1_gmc13:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_n4gc_b2073:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_n4gc_a1_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_n4gc_a1_gmc02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 512
+          name: ''
+      sgbg_n4gc_a1_gmc03:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 512
+          name: ''
+      sgbg_n4gc_a1_gmc04:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 512
+          name: ''
+      sgbg_n4gc_a1_gmc05:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+        - id: 8192
+          name: ''
+        - id: 16384
+          name: ''
+        - id: 32768
+          name: ''
+  ex3/01_nvt_n4/goe/n4gw/level/n4gw:
+    Name: Futures Rewritten (Ultimate)
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_n4g8_a1_gmc12:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+      sgbg_n4gw_a3_gmc12:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+      sgbg_n4gw_a3_gmc13:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+      sgvf_w_lvd_b1844:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+      sgvf_w_lvd_b1843:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_w_lvd_b1846:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+        - id: 8192
+          name: ''
+        - id: 16384
+          name: ''
+      sgbg_n4gw_a2_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+      sgvf_n4gw_b3561:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_n4gw_a3_ice01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+      sgbg_n4gw_a2_gmc17:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+      sgbg_n4gw_a2_gmc18:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+      sgbg_n4gw_a4_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+      sgbg_n4gc_a2_gmc19:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 128
+          name: ''
+      sgvf_w_lvd_b1845:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+      sgvf_n4gw_b3557:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+      sgbg_n4gw_a6_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgvf_n4gw_b3558:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_n4gw_b3559:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+  ex3/01_nvt_n4/rad/n4r1/level/n4r1:
+    Name: the Copied Factory
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_n4r1_a1_turo1:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_n4r1_a2_bwal1:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+        - id: 8192
+          name: ''
+        - id: 16384
+          name: ''
+        - id: 32768
+          name: ''
+      sgbg_n4r1_a2_bsta1:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+      sgbg_n4r1_a2_bstb1:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_n4r1_a2_bstb2:
+        Description: ''
+        States:
+        - id: 4
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+        - id: 16384
+          name: ''
+        - id: 32768
+          name: ''
+      sgbg_n4r1_a2_bstc1:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+      sgvf_n4r1_b1683:
+        Description: ''
+        States:
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+        - id: 8192
+          name: ''
+        - id: 16384
+          name: ''
+        - id: 32768
+          name: ''
+      sgbg_n4r1_a2_b2st1:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+      sgbg_n4r1_a3_gmc04:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgvf_n4r1_b1729:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_n4r1_a3_gmc06:
+        Description: ''
+        States:
+        - id: 4
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgvf_n4r1_b1732:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_n4r1_a0_gmc07:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_n4r1_a4_gmc02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_n4r1_a4_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_n4r1_b1809:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 4
+          name: ''
+        - id: 16
+          name: ''
+      sgvf_n4r1_b1818:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_n4r1_a1_hato1:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_n4r1_b1808:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_n4r1_b1746:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+  ex3/01_nvt_n4/rad/n4r2/level/n4r2:
+    Name: the Puppets' Bunker
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_n4r2_a1_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_n4r2_a2_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_n4r2_a2_gmc03:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_n4r2_a3_gmc11:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_n4r2_a4_gate1:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_n4r2_a4_sht01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgvf_n4r1_b1818:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_n4r2_a3_gmc15:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+      sgbg_n4r2_a3_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+      sgbg_n4r2_a4_brcd1:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_n4r2_a4_bmon1:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+      sgbg_n4r2_a4_gun12:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_n4r2_a4_gun14:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_n4r2_a3_gmc03:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+      sgbg_n4r2_a3_gmc1x:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+      sgbg_n4r2_a3_gmc06:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+        - id: 8192
+          name: ''
+        - id: 16384
+          name: ''
+      sgbg_n4r2_a3_gmc07:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgse_n4r2_b1874:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+  ex3/01_nvt_n4/rad/n4r3/level/n4r3:
+    Name: the Tower at Paradigm's Breach
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_n4r3_a4_egg01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_n4r3_a4_stag1:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+        - id: 8192
+          name: ''
+        - id: 16384
+          name: ''
+        - id: 32768
+          name: ''
+      sgvf_n4r3_b2176:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_n4r3_a4_rail1:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_n4r3_a4_sign1:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 512
+          name: ''
+        - id: 2048
+          name: ''
+      sgbg_n4r3_a4_trin1:
+        Description: ''
+        States:
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_n4r3_a4_trin2:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgbg_n4r3_a4_rail2:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_n4r3_a1_door1:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+      sgbg_n4r3_a1_door2:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+      sgvf_n4r1_b1818:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_n4r3_a4_bgex1:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_n4r3_a2_gmc04:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_n4r3_a2_gmc06:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+      sgbg_n4r3_a2_gmc07:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgbg_n4r3_a2_gmc08:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgvf_n4r3_b2188:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_n4r3_a2_gmc05:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_n4r3_a2_gmc16:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+      sgvf_n4r3_b2220:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgvf_n4r3_b2232:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_n4r3_a0_ven05:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+  ex3/02_dra_d4/dun/d4d1/level/d4d1:
+    Name: Matoya's Relict
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_d4d1_a0_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+      sgbg_d4d1_a1_gmc19:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_d4d1_a2_gmc03:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_d4d1_a2_gmc04:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_d4d1_a2_gmc12:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgbg_d4d1_a3_gmc07:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_d4d1_a3_gmc08:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_d4d1_a1_gmc21:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_d4d1_b1892:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_d4d1_b1893:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_d4d1_b2109:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgvf_d4d1_b1895:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_d4d1_a2_gmc10:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_d4d1_a2_gmc13:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 32
+          name: ''
+  ex3/04_wil_w4/dun/w4d1/level/w4d1:
+    Name: Paglth'an
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_w4d1_a1_gmc02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_w4d1_a2_gmc04:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_w4d1_a3_gmc06:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_w4d1_a2_gmc10:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_w4d1_a3_gmc11:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_w4d1_a2_gmc14:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 128
+          name: ''
+      sgbg_w4d1_a2_gmc15:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+      sgbg_w4d1_a2_gmc16:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgvf_w_lvd_b1256:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+  ex4/01_nvt_n5/dun/n5d1/level/n5d1:
+    Name: Ktisis Hyperboreia
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_n5d1_a1_gmc08:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+      sgbg_n5d1_a1_gmc09:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+      sgbg_n5d1_a1_gmc10:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+      sgvf_n5d1_b2351:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_n5d1_a2_gmc04:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_n5d1_a1_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_n5d1_a2_gmc03:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_n5d1_a2_gmc02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_n5d1_a3_gmc05:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_n5d1_a2_gmc06:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_n5d1_a1_gmc07:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 4
+          name: ''
+  ex4/01_nvt_n5/rad/n5r1/level/n5r1:
+    Name: 'Asphodelos: The First Circle'
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_n5r1_a1_gmc07:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 128
+          name: ''
+      sgbg_n5r1_a1_gmc06:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 128
+          name: ''
+      sgbg_n5r1_a1_gmc05:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 128
+          name: ''
+      sgvf_n5r1_b2283:
+        Description: ''
+        States:
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+      sgvf_n5r1_b2281:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgvf_n5r1_b2282:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 512
+          name: ''
+        - id: 2048
+          name: ''
+      sgbg_n5r1_a1_gmc03:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 32
+          name: ''
+        - id: 128
+          name: ''
+  ex4/01_nvt_n5/rad/n5r2/level/n5r2:
+    Name: 'Asphodelos: The Second Circle'
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_n5r2_a0_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgvf_n5r2_b2288:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgvf_n5r2_b2286:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+  ex4/01_nvt_n5/rad/n5r3/level/n5r3:
+    Name: 'Asphodelos: The Third Circle'
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgvf_n5r3_b2327:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgvf_n5r3_b2328:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_n5r3_b2330:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+  ex4/01_nvt_n5/rad/n5r4/level/n5r4:
+    Name: 'Asphodelos: The Fourth Circle'
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_n5r4_a1_gmc02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+      sgbg_n5r4_a1_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 32
+          name: ''
+      sgbg_n5r4_a1_gmc03:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 512
+          name: ''
+        - id: 2048
+          name: ''
+      sgbg_n5r4_a1_gmc04:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 512
+          name: ''
+        - id: 2048
+          name: ''
+      sgbg_n5r4_a1_gmc05:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 512
+          name: ''
+        - id: 2048
+          name: ''
+      sgbg_n5r4_a1_gmc06:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 512
+          name: ''
+        - id: 2048
+          name: ''
+      sgvf_n5r4_b2324:
+        Description: ''
+        States:
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 32
+          name: ''
+        - id: 128
+          name: ''
+      sgvf_n5r4_b2325:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+  ex4/01_nvt_n5/rad/n5r5/level/n5r5:
+    Name: 'Abyssos: The Fifth Circle'
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_n5r5_a1_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgbg_n5r5_a1_gmc02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgbg_n5r5_a1_gmc07:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+        - id: 8192
+          name: ''
+        - id: 16384
+          name: ''
+        - id: 32768
+          name: ''
+      sgbg_n5r5_a1_gmc08:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+  ex4/01_nvt_n5/rad/n5r6/level/n5r6:
+    Name: 'Abyssos: The Sixth Circle'
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_n5r6_a1_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 4096
+          name: ''
+        - id: 8192
+          name: ''
+        - id: 16384
+          name: ''
+        - id: 32768
+          name: ''
+      sgvf_n5r6_b2607:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+        - id: 8192
+          name: ''
+  ex4/01_nvt_n5/rad/n5r7/level/n5r7:
+    Name: 'Abyssos: The Seventh Circle'
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_n5r7_a0_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+        - id: 8192
+          name: ''
+        - id: 16384
+          name: ''
+        - id: 32768
+          name: ''
+      sgbg_n5r7_a0_gmc02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 128
+          name: ''
+      sgvf_n5r7_b2622:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+  ex4/01_nvt_n5/rad/n5r8/level/n5r8:
+    Name: 'Abyssos: The Eighth Circle'
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgvf_n5r8_b2573:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgvf_n5r8_b2575c:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+      sgvf_n5r8_b2757:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+      sgbg_n5r8_a1_gmc09:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+  ex4/01_nvt_n5/rad/n5r9/level/n5r9:
+    Name: 'Anabaseios: The Ninth Circle'
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_n5r9_a1_gmc03:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 32
+          name: ''
+        - id: 128
+          name: ''
+        - id: 512
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 8192
+          name: ''
+        - id: 32768
+          name: ''
+      sgvf_n5r9_b2781:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+  ex4/01_nvt_n5/rad/n5ra/level/n5ra:
+    Name: 'Anabaseios: The Tenth Circle'
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_n5ra_a1_gmc04:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_n5ra_a1_gmc03:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_n5ra_a1_gmc05:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_n5ra_a1_gmc02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_n5ra_a1_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_n5ra_b3007:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+  ex4/01_nvt_n5/rad/n5rb/level/n5rb:
+    Name: 'Anabaseios: The Eleventh Circle'
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgvf_n5rb_b2785:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_n5rb_a1_gmc03:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgbg_n5rb_a1_gmc02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgvf_n5rb_b2788:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 128
+          name: ''
+      sgvf_n5rb_b2789:
+        Description: ''
+        States:
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_n5rb_b2791:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 128
+          name: ''
+  ex4/01_nvt_n5/rad/n5rc/level/n5rc:
+    Name: 'Anabaseios: The Twelfth Circle'
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_n5rc_a1_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 32
+          name: ''
+        - id: 128
+          name: ''
+      sgbg_n5rc_a1_gmc02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 32
+          name: ''
+        - id: 128
+          name: ''
+      sgbg_n5rc_a1_gmc03:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_n5rc_a1_gmc08:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 32768
+          name: ''
+      sgvf_n5rc_b2806:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+  ex4/02_mid_m5/btl/m5b1/level/m5b1:
+    Name: A Frosty Reception
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_m5b1_a1_gmc03:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_m5b1_a1_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_m5b1_b2279:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_w_qic_004_03b:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_m5b1_a1_bomb1:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+  ex4/02_mid_m5/dun/m5d1/level/m5d1:
+    Name: the Tower of Zot
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgvf_m5d1_b2245:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_m5d1_b2246:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+      sgbg_m5d1_a1_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_m5d1_a1_gmc02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_m5d1_a1_gmc03:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_m5d1_a1_gmc04:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_m5d1_a2_gmc07:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_m5d1_a3_gmc09:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+  ex4/02_mid_m5/dun/m5d2/level/m5d2:
+    Name: the Tower of Babil
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgvf_m5d2_b2270:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_m5d2_a2_gmc22:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_m5d2_b2276:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_m5d2_a3_gmc24:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+      sgbg_m5d2_a1_gmc05:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_m5d2_a1_gmc06:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_m5d2_a1_gmc02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+      sgbg_m5d2_a2_gmc11:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+      sgbg_m5d2_a2_gmc13:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_m5d2_a3_gmc17:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_m5d2_a3_gmc19:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_m5d2_a1_gmc26:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+  ex4/02_mid_m5/dun/m5d3/level/m5d3:
+    Name: Vanaspati
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgvf_m5d3_b2384:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_m5d3_a1_gmc12:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+      sgvf_m5d3_b2383:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_m5d3_b2380:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_m5d3_a3_gmc16:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+      sgbg_m5d3_a3_gmc17:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_m5d3_a1_gmc10:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_m5d3_a1_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_m5d3_a2_gmc03:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_m5d3_a2_gmc21:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_m5d3_a2_gmc04:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_m5d3_a3_gmc05:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_m5d3_a3_gmc06:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_m5d3_a3_gmc08:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_m5d3_a3_gmc22:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 4
+          name: ''
+      sgvf_m5d3_b2374:
+        Description: ''
+        States:
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_m5d3_a2_gmc27:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+  ex4/02_mid_m5/dun/m5d4/level/m5d4:
+    Name: Alzadaal's Legacy
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_m5d4_a3_gmc12:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_m5d4_a3_gmc13:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+      sgbg_m5d4_a3_gmc15:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 32
+          name: ''
+        - id: 128
+          name: ''
+      sgbg_m5d4_a3_gmc14:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 32
+          name: ''
+        - id: 128
+          name: ''
+      sgvf_m5d4_b2531:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 32
+          name: ''
+        - id: 128
+          name: ''
+        - id: 512
+          name: ''
+      sgvf_m5d4_b2530:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 32
+          name: ''
+        - id: 128
+          name: ''
+        - id: 512
+          name: ''
+      sgbg_m5d4_a1_gmc02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_m5d4_a1_gmc03:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_m5d4_a2_gmc05:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_m5d4_a2_gmc06:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_m5d4_a3_gmc07:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_m5d4_a3_gmc08:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_m5d4_a1_gmc04:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+  ex4/02_mid_m5/dun/m5d5/level/m5d5:
+    Name: Lapis Manalis
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_m5d5_b3_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgbg_m5d5_b1_gmc02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgvf_m5d5_b2679:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_m5d5_b2681:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+      sgvf_m5d5_b2762b:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+      sgvf_m5d5_b2762a:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+      sgvf_m5d5_b2636:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgbg_m5d5_a1_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_m5d5_a1_gmc02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgvf_m5d5_b2722:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgbg_m5d5_a2_gmc03:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_m5d5_a2_gmc06:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_m5d5_a3_gmc04:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_m5d5_a1_gmc07:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_m5d5_b2680:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+  ex4/02_mid_m5/evt/m5e6/level/m5e6:
+    Name: Heroes and Pretenders
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgvf_w_lvd_b1820:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_m5e6_b3142:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+  ex4/02_mid_m5/fld/m5f2/level/m5f2:
+    Name: In from the Cold
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_m5f2_q0_wep03:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_w_evt_b2185:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+  ex4/02_mid_m5/fld/m5fa/level/m5fa:
+    Name: Mount Ordeals
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_m5fa_a0_gmc08:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 16384
+          name: ''
+        - id: 32768
+          name: ''
+      sgvf_m5fa_b2763a:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+      sgvf_m5fa_b2763b:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+      sgvf_m5fa_b2763c:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+      sgvf_m5fa_b2764a:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+      sgvf_m5fa_b2772:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+  ex4/02_mid_m5/fld/m5fb/level/m5fb:
+    Name: the Gilded Araya
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgvf_m5fb_b2909:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_m5fb_b2872:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+  ex4/03_kld_k5/dun/k5d1/level/k5d1:
+    Name: the Aitiascope
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_k5d1_a2_gmc18:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_k5d1_a2_gmc19:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+      sgbg_k5d1_a3_gmc21:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_k5d1_a1_gmc04:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgvf_k5d1_b2192:
+        Description: ''
+        States:
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_k5d1_b2354:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_k5d1_a1_gmc06:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgvf_k5d1_b2356:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+      sgbg_k5d1_a2_gmc08:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_k5d1_a2_gmc24:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgvf_k5d1_b2363:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgbg_k5d1_a3_gmc11:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+      sgbg_k5d1_a3_gmc14:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_k5d1_a3_gmc16:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_k5d1_a3_gmc13:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgvf_k5d1_b2355:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_k5d1_a0_gmc30:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+  ex4/03_kld_k5/dun/k5d2/level/k5d2:
+    Name: the Aetherfont
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgvf_k5d2_b2904:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_k5d2_b2905:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 16384
+          name: ''
+        - id: 32768
+          name: ''
+      sgbg_k5d2_b3_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+      sgbg_k5d2_b3_gmc02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+      sgbg_k5d2_a1_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_k5d2_a1_gmc02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_k5d2_a3_gmc08:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_k5d2_a3_gmc09:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_k5d2_a1_gmc04:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_k5d2_a2_gmc05:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_k5d2_a2_gmc06:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_k5d2_a2_gmc07:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_k5d2_b1_gmc03:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+  ex4/03_kld_k5/fld/k5fa/level/k5fa:
+    Name: the Mothercrystal
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_k5fa_a0_rng01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_k5fa_a0_cry08:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_k5fa_a0_cry01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+      sgbg_k5fa_a0_cry02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+      sgbg_k5fa_a0_cry03:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+      sgbg_k5fa_a0_cry04:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+      sgbg_k5fa_a0_cry05:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+      sgbg_k5fa_a0_cry06:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+      sgbg_k5fa_a0_bar01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgvf_k5fa_b2505:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+      sgbg_k5fa_a0_mag01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_k5fa_b2112:
+        Description: ''
+        States:
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_k5fa_a0_rot01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+  ex4/04_uvs_u5/dun/u5d1/level/u5d1:
+    Name: the Dead Ends
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_u5d1_a3_gmc15:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_u5d1_a1_gmc02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_u5d1_a1_gmc03:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_u5d1_a2_gmc16:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_u5d1_a2_gmc30:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_u5d1_a2_gmc04:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_u5d1_a2_gmc07:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgbg_u5d1_a2_gmc08:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgbg_u5d1_a2_gmc11:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 128
+          name: ''
+      sgbg_u5d1_a2_gmc13:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgvf_u5d1_b2039:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_u5d1_a2_gmc17:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_u5d1_a3_gmc19:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_u5d1_a3_gmc06:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgvf_u5d1_b2133:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_u5d1_b2042:
+        Description: ''
+        States:
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgvf_u5d1_b2134:
+        Description: ''
+        States:
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_u5d1_a2_gmc24:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_u5d1_a2_gmc25:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_u5d1_a2_gmc26:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_u5d1_a2_gmc27:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_u5d1_a2_gmc28:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_u5d1_a2_gmc29:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_u5d1_a2_gmc99:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_u5d1_b2136:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+      sgbg_u5d1_a2_gmc22:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+  ex4/04_uvs_u5/dun/u5d2/level/u5d2:
+    Name: Smileton
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgvf_u5d2_b2321:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+      sgbg_u5d2_a3_gmc12:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 32
+          name: ''
+      sgbg_u5d2_a1_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_u5d2_a1_gmc01b:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_u5d2_a2_gmc02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_u5d2_a2_gmc03:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_u5d2_a2_gmc04:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_u5d2_a2_gmc05:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_u5d2_a3_gmc07:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_u5d2_a3_gmc15:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_u5d2_a3_gmc16:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+  ex4/04_uvs_u5/dun/u5d3/level/u5d3:
+    Name: the Stigma Dreamscape
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_u5d3_a3_gmc13:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_u5d3_a3_gmc14:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_u5d3_a3_gmc15:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_u5d3_a1_gmc11:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_u5d3_a1_gmc03:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_u5d3_a1_gmc04:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_u5d3_a1_gmc05:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_u5d3_a0_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+      sgbg_u5d3_a2_gmc06:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_u5d3_a2_gmc07:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_u5d3_a3_gmc08:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgbg_u5d3_a3_gmc10:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_u5d3_a1_gmc17:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+  ex4/04_uvs_u5/evt/u5e1/level/u5e1:
+    Name: Endwalker
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_u5e1_a0_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_u5f1_b2460:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+  ex4/04_uvs_u5/fld/u5fa/level/u5fa:
+    Name: the Dark Inside
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_u5fa_b0_mag03:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_u5fa_b2048:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+      sgbg_u5fa_rotate02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_u5fa_normal_stage_rotate02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+      sgvf_u5fa_b2049:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+      sgvf_u5fa_b2050:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+        - id: 8192
+          name: ''
+      sgbg_u5fa_a0_ida13_04:
+        Description: ''
+        States:
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+        - id: 8192
+          name: ''
+        - id: 16384
+          name: ''
+      sgbg_u5fa_a0_ida12_04:
+        Description: ''
+        States:
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+        - id: 8192
+          name: ''
+        - id: 16384
+          name: ''
+      sgbg_u5fa_a0_ida14_04:
+        Description: ''
+        States:
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+        - id: 8192
+          name: ''
+        - id: 16384
+          name: ''
+  ex4/04_uvs_u5/fld/u5fb/level/u5fb:
+    Name: the Final Day
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      u5fb_a0_planetrain02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgbg_u5fb_u0_bgscroll01__hie04:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+        - id: 32768
+          name: ''
+      sgvf_u5fb_b2405:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+      sgvf_u5fb_b2407:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_u5fb_b2411:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+  ex4/05_zon_z5/dun/z5d1/level/z5d1:
+    Name: the Fell Court of Troia
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgvf_z5d1_b2495:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_z5d1_b2496:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_z5d1_b3_gmc02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_z5d1_b3_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgbg_z5d1_a1_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_z5d1_a1_gmc02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_z5d1_a2_gmc03:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_z5d1_a2_gmc04:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_z5d1_a3_gmc05:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_z5d1_a3_gmc07:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_z5d1_b2620:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_z5d1_a3_gmc09:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 4
+          name: ''
+  ex4/05_zon_z5/dun/z5d2/level/z5d2:
+    Name: the Lunar Subterrane
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgvf_z5d2_b3004:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_z5d2_b2_gmc03:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgvf_z5d2_b2976:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgvf_z5d2_b2977:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_z5d2_a1_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_z5d2_a1_gmc02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 16384
+          name: ''
+        - id: 32768
+          name: ''
+      sgbg_z5d2_a2_gmc05:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_z5d2_a2_gmc03:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_z5d2_a2_gmc06:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_z5d2_a2_gmc04:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_z5d2_a3_gmc07:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_z5d2_a3_gmc08:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+  ex4/05_zon_z5/fld/z5fa/level/z5fa:
+    Name: Storm's Crown
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_z5fa_a1_bst01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_z5fa_b2447:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+  ex4/05_zon_z5/fld/z5fb/level/z5fb:
+    Name: the Voidcast Dais
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgvf_z5fb_b2777:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_z5fb_a1_gmc03:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 4
+          name: ''
+      sgvf_z5fb_b2778:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_z5fb_a1_gmc04:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+  ex4/05_zon_z5/fld/z5fc/level/z5fc:
+    Name: the Abyssal Fracture
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgvf_z5fc_b2912:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_z5fc_b3088:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+  ex4/05_zon_z5/fld/z5fd/level/z5fd:
+    Name: the Unmaking
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgvf_z5fd_b4251:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgvf_z5fd_b4252:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+      sgvf_z5fd_b4253:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+      sgvf_z5fd_b4255:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+  ex4/05_zon_z5/rad/z5r1/level/z5r1:
+    Name: Aglaia
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgvf_z5r1_b2472:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_z5r1_a1_gmc02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 128
+          name: ''
+        - id: 512
+          name: ''
+      sgbg_z5r1_a1_gmc03:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 512
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 8192
+          name: ''
+        - id: 32768
+          name: ''
+      sgbg_z5r1_a1_gmc04:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 8192
+          name: ''
+        - id: 16384
+          name: ''
+        - id: 32768
+          name: ''
+      sgbg_z5r1_a1_gmc05:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+      sgvf_z5r1_b2474:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgvf_z5r1_b2431:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+      sgvf_z5r1_b2429:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgvf_z5r1_b2430:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 32
+          name: ''
+        - id: 128
+          name: ''
+        - id: 512
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 8192
+          name: ''
+      sgvf_z5r1_b2554:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_z5r1_a2_gmc01:
+        Description: ''
+        States:
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+      sgbg_z5r1_a2_gmc03:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_z5r1_b2432:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+      sgbg_z5r1_a4_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+        - id: 8192
+          name: ''
+        - id: 16384
+          name: ''
+        - id: 32768
+          name: ''
+      sgvf_z5r1_b2548:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_z5r1_a4_gmc12:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+        - id: 8192
+          name: ''
+        - id: 32768
+          name: ''
+      sgbg_z5r1_a4_gmc14:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 128
+          name: ''
+      sgvf_z5r1_b2544:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+      sgvf_z5r1_b2545:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+      sgvf_z5r1_b2546:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+      sgvf_z5r1_b2543:
+        Description: ''
+        States:
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_z5r1_a4_gmc26:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_z5r1_b2542:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_z5r1_a0_gmc03:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+      sgbg_z5r1_a0_gmc02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 16
+          name: ''
+      sgbg_z5r1_a0_gmc04:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+      sgvf_z5r1_b2553:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgvf_z5r1_b2601:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_z5r1_a0_gmc10:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgbg_z5r1_a0_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+  ex4/05_zon_z5/rad/z5r2/level/z5r2:
+    Name: Euphrosyne
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgvf_z5r2_b2588:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_z5r2_b2587:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgvf_z5r2_b2587b:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgvf_z5r2_b2587c:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgvf_z5r2_b2587d:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 128
+          name: ''
+      sgbg_z5r2_a3_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgbg_z5r2_a3_gmc02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgvf_z5r2_b2589:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_z5r2_a4_gmc08:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_z5r2_b2580:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 512
+          name: ''
+      sgvf_z5r2_b2582:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 256
+          name: ''
+      sgvf_z5r2_b2582a:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 256
+          name: ''
+      sgvf_z5r2_b2581:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 256
+          name: ''
+      sgvf_z5r2_b2581a:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 256
+          name: ''
+      sgvf_z5r2_b2581b:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 256
+          name: ''
+      sgvf_z5r2_b2765:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_z5r2_a1_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+        - id: 8192
+          name: ''
+        - id: 16384
+          name: ''
+      sgbg_z5r2_a0_gmc04:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_z5r2_a0_gmc07:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_z5r2_a0_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+      sgbg_z5r2_a0_gmc02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgvf_z5r2_b2586:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgvf_z5r2_b2585:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+      sgbg_z5r2_a0_gmc06:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgvf_z5r2_b2587e:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+      sgvf_z5r2_b2901:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+  ex4/05_zon_z5/rad/z5r3/level/z5r3:
+    Name: Thaleia
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_z5r3_a1_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+      sgbg_z5r3_a1_gmc09:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+      sgbg_z5r3_a1_gmc08:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgbg_z5r3_a1_gmc02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_z5r3_a1_gmc03:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgvf_z5r3_b3008:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_z5r3_b3009:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_z5r3_b3010:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_z5r3_a1_gmc07:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+      sgvf_z5r3_b3069:
+        Description: ''
+        States:
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgvf_z5r3_b3067:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_z5r3_a2_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+        - id: 8192
+          name: ''
+      sgbg_z5r3_a5_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+        - id: 8192
+          name: ''
+        - id: 16384
+          name: ''
+      sgvf_z5r3_b3012:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+        - id: 8192
+          name: ''
+        - id: 16384
+          name: ''
+        - id: 32768
+          name: ''
+      sgvf_z5r2_b2587d:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 128
+          name: ''
+      sgvf_z5r2_b2587b:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgvf_z5r2_b2587:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgvf_z5r2_b2587e:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+      sgbg_z5r3_a5_gmc03:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+      sgbg_z5r3_a5_gmc04:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+        - id: 8192
+          name: ''
+      sgbg_z5r3_a0_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_z5r3_a0_gmc03:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgvf_z5r3_b3014:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgvf_z5r3_b3016:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 32
+          name: ''
+      sgvf_z5r3_b3020:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgvf_z5r3_b3015:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_z5r3_a0_gmc07:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_z5r3_a0_gmc08:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 128
+          name: ''
+      sgbg_z5r3_a3_gmc02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+      sgbg_z5r3_a0_gmc09:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_z5r3_a0_gmc10:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgbg_z5r3_a3_gmc06:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_z5r3_a3_gmc07:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_z5r3_a3_gmc08:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_z5r3_b3095:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgvf_z5r3_b2873:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+      sgbg_z5r3_a3_gmc09:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 4
+          name: ''
+      sgvf_z5r3_b3025:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_z5r3_b3025a:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+  ex4/06_wil_w5/dun/w5d1/level/w5d1:
+    Name: the Sil'dihn Subterrane
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_w5d1_bb_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+      sgvf_w5d1_b2654:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_w5d1_b2750:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+      sgbg_w5d1_aa_gmc03:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 128
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+      sgbg_w5d1_aa_gmc04:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+        - id: 8192
+          name: ''
+        - id: 16384
+          name: ''
+        - id: 32768
+          name: ''
+      sgbg_w5d1_aa_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 128
+          name: ''
+        - id: 512
+          name: ''
+      sgvf_w5d1_b2702:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_w5d1_b2561:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_w5d1_a1_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_w5d1_a1_gmc04:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_w5d1_a1_gmc05:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_w5d1_a1_gmc06:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_w5d1_a1_gmc08:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_w5d1_a2_gmc10:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_w5d1_a2_gmc58:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_w5d1_b2_gmc34:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 4
+          name: ''
+      sgvf_w_lvd_b2617:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+      sgbg_w5d1_bb_gmc55:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_w5d1_a1_gmc09:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_w5d1_b1_gmc25:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_w5d1_a2_gmc14:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_w5d1_a2_gmc13:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_w5d1_a2_gmc15:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_w5d1_a2_gmc21:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 16
+          name: ''
+      sgbg_w5d1_a2_gmc16:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgbg_w5d1_a2_gmc19:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgbg_w5d1_a2_gmc20:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_w5d1_b1_gmc23:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_w5d1_c2_gmc49:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_w5d1_c2_gmc51:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_w5d1_c2_gmcb:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_w5d1_b1_gmc24:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_w5d1_b2_gmc59:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgbg_w5d1_b2_gmc26:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_w5d1_b2_gmc28:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_w5d1_b2_gmc29:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_w5d1_b2_gmc57:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_w5d1_b2_gmc31:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgbg_w5d1_b2_gmc30:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_w5d1_b2_gmc32:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_w5d1_bb_gmc54:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_w5d1_c1_gmc35:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_w5d1_c1_gmc36:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_w5d1_c1_gmc37:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_w5d1_c1_gmc38:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_w5d1_c1_gmc39:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgbg_w5d1_c2_gmc60:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_w5d1_c2_gmc40:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_w5d1_c2_gmc42:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_w5d1_c2_gmc43:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_w5d1_c2_gmc45:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_w5d1_c2_gmc46:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_w5d1_c2_gmc48:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_w5d1_c2_gmc47:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_w5d1_c2_gmc44:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_w5d1_c2_gmc50:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_w5d1_c2_gmc52:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgbg_w5d1_c2_gmc53:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgbg_w5d1_b2_gmc33:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgbg_col_wall_02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 4
+          name: ''
+      sgvf_w5d1_b2656a:
+        Description: ''
+        States:
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+  ex4/06_wil_w5/dun/w5d2/level/w5d2:
+    Name: Another Sil'dihn Subterrane
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_w5d1_a2_gmc14:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgvf_w5d1_b2654:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_w5d1_b2561:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_w_lvd_b2697:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_w5d1_c2_gmc51:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+  ex4/07_lak_l5/cnt/l5c1/level/l5c1:
+    Name: Eureka Orthos (Floors 1-10)
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_l5c1_a0_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+  ex4/07_lak_l5/cnt/l5c3/level/l5c3:
+    Name: Eureka Orthos (Floors 31-40)
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgvf_l5c3_b2736:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+  ex4/07_lak_l5/cnt/l5c4/level/l5c4:
+    Name: Eureka Orthos (Floors 51-60)
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgvf_l5c4_b2737:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+  ex4/07_lak_l5/cnt/l5c5/level/l5c5:
+    Name: Eureka Orthos (Floors 71-80)
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgvf_l5c5_b2738:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+  ex4/08_est_e5/dun/e5d1/level/e5d1:
+    Name: Mount Rokkon
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgvf_w_lvd_b2617:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+      sgbg_e5d1_a0_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgvf_e5d1_b2696:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_e5d1_a1_gmc03:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_e5d1_a1_gmc04:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+      sgbg_e5d1_a1_gmc05:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+      sgbg_e5d1_a1_gmc06:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgbg_e5d1_a1_gmc07:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_e5d1_a1_gmc09:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+      sgbg_e5d1_a1_gmc08:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgvf_e5d1_b2969:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_e5d1_a1_gmc10:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_e5d1_a1_gmc12:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 4
+          name: ''
+      sgvf_e5d1_b3000:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_e5d1_b2868:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_w_btl_b3100:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+      sgvf_e5d1_b2853:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_e5d1_b2970:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_e5d1_a2_gmc13:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_e5d1_a2_gmc14:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_e5d1_a2_gmc15:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_e5d1_a2_gmc21:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_e5d1_a2_gmc16:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_e5d1_a2_gmc18:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_e5d1_a2_gmc17:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgvf_e5d1_b2858:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_e5d1_b0_gmc06:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+      sgbg_e5d1_b0_gmc07:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgbg_e5d1_b2_gmc07:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgvf_e5d1_b2699:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_e5d1_a2_gmc19:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_e5d1_a2_gmc22:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgbg_e5d1_a3_gmc23:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_e5d1_a3_gmc24:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_e5d1_a3_gmc26:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_e5d1_a3_gmc27:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_e5d1_a3_gmc30:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_e5d1_a3_gmc28:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgvf_e5d1_b2795:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_e5d1_b2793:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgvf_e5d1_b2794:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgvf_e5d1_b2863:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_e5d1_b2865:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_e5d1_a3_gmc29:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_e5d1_a3_gmc32:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_e5d1_a3_gmc31:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_e5d1_a3_gmc33:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgvf_e5d1_b2962:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_e5d1_a1_gmc11:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_w_new_013_01b:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 4096
+          name: ''
+      sgbg_e5d1_a4_gmc34:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_e5d1_a4_gmc36:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_e5d1_a2_gmc37:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_e5d1_a2_gmc38:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+  ex4/08_est_e5/dun/e5d2/level/e5d2:
+    Name: Another Mount Rokkon
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgvf_e5d1_b3002:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+      sgvf_e5d1_b3000:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_e5d1_b2868:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_e5d1_b2867:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_w_btl_b1879:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+      sgvf_w_btl_b3100:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+      sgvf_e5d1_b2795:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_e5d1_b2793:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgvf_e5d1_b2794:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgvf_e5d1_b2871:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_e5d1_b2864:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+  ex4/09_ocn_o5/dun/o5d1/level/o5d1:
+    Name: Aloalo Island
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgvf_w_lvd_b2617:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+      sgbg_o5d1_a5_gmc33:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgbg_o5d1_a1_gmc30:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_o5d1_a1_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_o5d1_a1_gmc04:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_o5d1_a1_gmc02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 4
+          name: ''
+      sgvf_o5d1_b3158:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgbg_o5d1_b4_gmc02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 8192
+          name: ''
+        - id: 16384
+          name: ''
+        - id: 32768
+          name: ''
+      sgbg_o5d1_b4_gmc03:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+      sgbg_o5d1_b4_gmc05:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgbg_o5d1_b4_gmc06:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_o5d1_a3_gmc18:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgvf_o5d1_b3114:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_o5d1_a3_gmc29:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_o5d1_a3_gmc17:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgvf_o5d1_b2820:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+      sgvf_o5d1_b3062:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_o5d1_b3064:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+        - id: 8192
+          name: ''
+      sgbg_o5d1_b0_gmc04:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+      sgbg_o5d1_a2_gmc05:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_o5d1_b3_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+        - id: 8192
+          name: ''
+        - id: 16384
+          name: ''
+        - id: 32768
+          name: ''
+      sgbg_o5d1_b3_gmc05:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 32
+          name: ''
+      sgvf_o5d1_b2804:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_o5d1_a2_gmc08:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_o5d1_a2_gmc06:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_o5d1_a2_gmc10:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+      sgbg_o5d1_a2_gmc09:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_o5d1_a3_gmc11:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_o5d1_a3_gmc13:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_o5d1_a3_gmc12:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_o5d1_a1_gmc25:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_o5d1_a2_gmc26:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_o5d1_a3_gmc27:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_o5d1_a4_gmc28:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_o5d1_a3_gmc15:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_o5d1_a3_gmc19:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+      sgbg_o5d1_a3_gmc20:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+      sgbg_o5d1_a3_gmc21:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+      sgbg_o5d1_a3_gmc24:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+      sgvf_o5d1_b3101a:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_o5d1_a4_gmc31:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+      sgbg_o5d1_b4_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+  ex4/09_ocn_o5/dun/o5d2/level/o5d2:
+    Name: Another Aloalo Island
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgvf_o5d1_b2819:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_w_btl_b1879:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+      sgvf_o5d1_b2820:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+      sgvf_o5d1_b3158:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgvf_o5d1_b2804:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_o5d1_b3_gmc02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+      sgbg_o5d1_b3_gmc05:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 32
+          name: ''
+      sgvf_o5d2_b2747:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+  ex5/01_xkt_x6/cnt/x6c1/level/x6c1:
+    Name: Vault Oneiron
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_x6c1_p0_slt05:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+        - id: 8192
+          name: ''
+      sgbg_x6c1_p0_slt01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+        - id: 8192
+          name: ''
+        - id: 16384
+          name: ''
+      sgbg_x6c1_p0_slt02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+        - id: 8192
+          name: ''
+        - id: 16384
+          name: ''
+      sgbg_x6c1_p0_slt04:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+        - id: 8192
+          name: ''
+        - id: 16384
+          name: ''
+      sgbg_x6c1_p0_slt03:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+        - id: 8192
+          name: ''
+        - id: 16384
+          name: ''
+      sgbg_x6c1_p0_slt06:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+        - id: 8192
+          name: ''
+      sgbg_x6c1_p0_slt07:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+        - id: 8192
+          name: ''
+        - id: 16384
+          name: ''
+        - id: 32768
+          name: ''
+      sgvf_x6c1_b3801:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgbg_x6c1_p0_stg01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+      sgvf_x6c1_b3820:
+        Description: ''
+        States:
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgvf_x6c1_b3821:
+        Description: ''
+        States:
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_x6c1_p0_slt05x:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+        - id: 8192
+          name: ''
+      sgbg_x6c1_p0_slt01x:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+        - id: 8192
+          name: ''
+        - id: 16384
+          name: ''
+      sgbg_x6c1_p0_slt02x:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+        - id: 8192
+          name: ''
+        - id: 16384
+          name: ''
+      sgbg_x6c1_p0_slt04x:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+        - id: 8192
+          name: ''
+        - id: 16384
+          name: ''
+      sgbg_x6c1_p0_slt03x:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+        - id: 8192
+          name: ''
+        - id: 16384
+          name: ''
+  ex5/01_xkt_x6/dun/x6d1/level/x6d1:
+    Name: Vanguard
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgvf_x6d1_b2839:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_x6d1_b2840:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgvf_x6d1_b2840a:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgbg_x6d1_a1_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_x6d1_a0_gmc02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_x6d1_a0_gmc04:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_x6d1_a0_gmc03:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_x6d1_a3_gmc05:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgvf_x6d1_b2836:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_x6d1_b2835:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgvf_x6d1_b2838:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_x6d1_b1_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+  ex5/01_xkt_x6/dun/x6d2/level/x6d2:
+    Name: Origenics
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_x6d2_a1_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_x6d2_a1_gmc02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_x6d2_a1_gmc04:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_x6d2_a1_gmc05:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_x6d2_a1_gmc19:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_x6d2_a1_gmc07:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgbg_x6d2_a2_gmc08:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_x6d2_a2_gmc09:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_x6d2_a2_gmc11:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_x6d2_a2_gmc10:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_x6d2_a2_gmc16:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_x6d2_a3_gmc13:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgbg_x6d2_a3_gmc14:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_x6d2_a3_gmc15:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+      sgbg_x6d2_a1_gmc03:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgvf_x6d2_b3120a:
+        Description: ''
+        States:
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_x6d2_b3160:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_x6d2_b2_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+      sgbg_x6d2_b2_gmc02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_x6d2_b2_gmc04:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_x6d2_b2_gmc03:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_x6d2_b1_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 32
+          name: ''
+        - id: 128
+          name: ''
+      sgbg_x6d2_b3_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgvf_x6d2_b3162:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_x6d2_b3163:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_x6d2_a2_gmc18:
+        Description: ''
+        States:
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+  ex5/01_xkt_x6/dun/x6d3/level/x6d3:
+    Name: Alexandria
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_x6d3_b1_gmc02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+      sgbg_x6d3_a0_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgvf_x6d3_b2889:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_x6d3_a1_gmc02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_x6d3_a2_gmc03:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgbg_x6d3_a1_gmc15:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgbg_x6d3_a2_gmc16:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_x6d3_a2_gmc09:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgvf_x6d3_b2885:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_x6d3_a2_gmc04:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_x6d3_a3_gmc05:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgvf_x6d3_b2886:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgvf_x6d3_b2887:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgvf_x6d3_b2888:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_x6d3_b2_gmc02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgvf_x6d3_b2893:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_x6d3_b2895:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_x6d3_b3_gmc02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 128
+          name: ''
+      sgvf_x6d3_b2897:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_x6d3_a2_gmc14:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 32
+          name: ''
+      sgvf_x6d3_b2899:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+  ex5/01_xkt_x6/dun/x6d4/level/x6d4:
+    Name: Tender Valley
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_x6d4_b3_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_x6d4_b3_gmc05:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+      sgbg_x6d4_b3_gmc10:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_x6d4_b1_gmc03:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_x6d4_a1_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_x6d4_a2_gmc02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_x6d4_a3_gmc03:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_x6d4_a3_gmc04:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgvf_x6d4_b2844:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_x6d4_a3_gmc07:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_x6d4_a3_gmc05:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+  ex5/01_xkt_x6/dun/x6d5/level/x6d5:
+    Name: The Strayborough Deadwalk
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgvf_x6d5_b3038:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_x6d5_b2_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+        - id: 8192
+          name: ''
+      sgbg_x6d5_b2_gmc02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+      sgbg_x6d5_b3_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgbg_x6d5_b3_gmc02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+      sgbg_x6d5_b3_gmc05:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_x6d5_a1_gmc03:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_x6d5_a1_gmc02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_x6d5_a2_gmc05:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_x6d5_a2_gmc07:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgbg_x6d5_a3_gmc09:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_x6d5_a3_gmc10:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgbg_x6d5_a1_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_x6d5_a1_gmc11:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_x6d5_a2_gmc04:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_x6d5_a3_gmc08:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgvf_x6d5_b3047:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_x6d5_b3049:
+        Description: ''
+        States:
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_x6d5_b2_gmc03:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+        - id: 8192
+          name: ''
+      sgbg_x6d5_b1_gmc03:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+  ex5/01_xkt_x6/dun/x6d6/level/x6d6:
+    Name: Yuweyawata Field Station
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_x6d6_a3_gmc03:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_x6d6_a1_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_x6d6_a2_gmc02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_x6d6_a2_gmc07:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_x6d6_b2_gmc02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+      sgvf_x6d6_b3502:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_x6d6_b1_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+        - id: 8192
+          name: ''
+        - id: 32768
+          name: ''
+      sgvf_x6d6_b3501:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 128
+          name: ''
+      sgbg_x6d6_b3_gmc02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+      sgbg_x6d6_a3_gmc04:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 8192
+          name: ''
+        - id: 16384
+          name: ''
+        - id: 32768
+          name: ''
+      sgvf_x6d6_b3412:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_x6d6_a3_gmc06:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+      sgbg_x6d6_a2_gmc08:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgvf_x6d6_b3504:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+  ex5/01_xkt_x6/dun/x6d7/level/x6d7:
+    Name: the Underkeep
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_x6d7_a1_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_x6d7_a1_gmc02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_x6d7_a2_gmc03:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_x6d7_a2_gmc04:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_x6d7_a2_gmc05:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_x6d7_a3_gmc06:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_x6d7_a3_gmc07:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_x6d7_a3_gmc08:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_x6d7_a3_gmc09:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_x6d7_b3_gmc02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 512
+          name: ''
+      sgbg_x6d7_b3_gmc03:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_x6d7_b3443:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+        - id: 8192
+          name: ''
+      sgbg_x6d7_b2_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgbg_x6d7_a2_gmc10:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+  ex5/01_xkt_x6/dun/x6d8/level/x6d8:
+    Name: the Meso Terminal
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_x6d8_b3_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_x6d8_b3_gmc02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_x6d8_b3_gmc03:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_x6d8_b3_gmc04:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 16384
+          name: ''
+        - id: 32768
+          name: ''
+      sgvf_x6d8_b3598:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_x6d8_b1_gmc03:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+      sgbg_x6d8_b1_gmc02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+      sgvf_x6d8_b3751:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgvf_x6d8_b3752:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgvf_x6d8_b3753:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+      sgvf_x6d8_b3753a:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+      sgbg_x6d8_b2_gmc03:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+      sgbg_x6d8_b2_gmc02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 32
+          name: ''
+      sgbg_x6d8_b2_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_x6d8_a0_gmc12:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+      sgbg_x6d8_a0_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_x6d8_a1_gmc07:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_x6d8_a1_gmc02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_x6d8_a1_gmc10:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_x6d8_a0_gmc03:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_x6d8_a2_gmc08:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_x6d8_a2_gmc05:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_x6d8_a2_gmc11:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_x6d8_a3_gmc09:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_x6d8_a3_gmc06:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgvf_x6d8_b3597:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+  ex5/01_xkt_x6/dun/x6d9/level/x6d9:
+    Name: Mistwake
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_x6d9_a1_gmc02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_x6d9_a2_gmc06:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_x6d9_a2_gmc07:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_x6d9_a3_gmc08:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_x6d9_a3_gmc09:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_x6d9_a1_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_x6d9_b1_gmc03:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_x6d9_b1_gmc02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_x6d9_b1_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgvf_x6d9_b3330:
+        Description: ''
+        States:
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgvf_x6d9_b3330a:
+        Description: ''
+        States:
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgvf_x6d9_b3330b:
+        Description: ''
+        States:
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgvf_x6d9_b3329:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+  ex5/01_xkt_x6/evt/x6e7/level/x6e7:
+    Name: Bar the Passage
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgvf_x6e7_b3266:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_w_lvd_b1199a:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_x6e7_b3270:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+  ex5/01_xkt_x6/evt/x6ec/level/x6ec:
+    Name: Clotted Crime
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgvf_x6ec_b3338:
+        Description: ''
+        States:
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+  ex5/01_xkt_x6/fld/x6f1/level/x6f1:
+    Name: The Warmth of Family
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgvf_w_lvd_b1199a:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+  ex5/01_xkt_x6/fld/x6fa/level/x6fa:
+    Name: Everkeep
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgvf_x6fa_b3229:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgvf_x6fa_b3228:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_x6fa_b3232:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+      sgvf_x6fa_b3232a:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgvf_x6fa_b3235b:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+      sgvf_x6fa_b3235a:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_x6fa_a1_gimc3:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+      sgvf_x6fa_b3231:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+      sgvf_x6fa_b3249:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+  ex5/01_xkt_x6/fld/x6fb/level/x6fb:
+    Name: the Interphos
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_x6fb_a0_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+      sgbg_x6fb_a0_gmc02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+      sgbg_x6fb_a0_gmc03:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+      sgbg_x6fb_a0_gmc04:
+        Description: ''
+        States:
+        - id: 4
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+        - id: 8192
+          name: ''
+        - id: 16384
+          name: ''
+        - id: 32768
+          name: ''
+      sgbg_x6fb_a1_emer1:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+  ex5/01_xkt_x6/fld/x6fc/level/x6fc:
+    Name: "the Minstrel's Ballad: Sphene's Burden"
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_x6fb_a0_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+      sgbg_x6fc_a0_gmc02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+      sgbg_x6fc_a0_gmc03:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+      sgbg_x6fb_a1_emer1:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_x6fc_a7_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+      sgbg_x6fc_a8_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 16
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+      sgbg_x6fc_a8_gmc02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+      sgbg_x6fc_a8_gmc03:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+      sgbg_x6fc_a8_gmc07:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+      sgbg_x6fc_a8_gmc00:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+      sgvf_x6fc_b3189:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+        - id: 8192
+          name: ''
+      sgvf_x6fc_b3181:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_x6fc_b3182:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+      sgvf_x6fc_b3190:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+  ex5/01_xkt_x6/fld/x6fd/level/x6fd:
+    Name: Recollection
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgvf_x6fd_b3581:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_x6fd_b3582:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_x6fd_b3583:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 64
+          name: ''
+      sgvf_x6fd_b3584:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+      sgvf_x6fd_b3585:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+        - id: 8192
+          name: ''
+        - id: 16384
+          name: ''
+        - id: 32768
+          name: ''
+      sgbg_x6fd_a1_gmc00:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+  ex5/01_xkt_x6/fld/x6fe/level/x6fe:
+    Name: the Ageless Necropolis
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgvf_w_lvd_b2922:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_x6fe_b3804:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_x6fe_b3809:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+      sgvf_x6fe_b3805:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+  ex5/01_xkt_x6/fld/x6ff/level/x6ff:
+    Name: the Windward Wilds
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgvf_x6ff_b3754:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+      sgvf_x6ff_b3756:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_x6ff_b3758:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_x6ff_c1_col01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+  ex5/01_xkt_x6/fld/x6fg/level/x6fg:
+    Name: Hell on Rails
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgvf_x6fg_b3716:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_x6fg_a0_warp1:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+      sgbg_x6fg_a0_stg01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+      sgbg_x6fg_a0_stg02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_w_lvd_b2922:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_x6fg_a0_scr01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_x6fg_a0_box01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+      sgvf_x6fg_b3717:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_x6fg_b3722:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_x6fg_b3721:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_x6fg_b3720:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_x6fg_a0_lit01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_x6fg_a0_lit02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_x6fg_a0_lit03:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_x6fg_a0_lit04:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_x6fg_a0_lit05:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_x6fg_a0_col0a:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+      sgbg_x6fg_a3_stc04:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+  ex5/01_xkt_x6/rad/x6r1/level/x6r1:
+    Name: AAC Light-heavyweight M1
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_x6r1_a1_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+      sgvf_x6r1_b3048:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+  ex5/01_xkt_x6/rad/x6r2/level/x6r2:
+    Name: AAC Light-heavyweight M2
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgvf_x6r2_b3035:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_x6r2_a1_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+      sgvf_x6r2_b3045:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+  ex5/01_xkt_x6/rad/x6r3/level/x6r3:
+    Name: AAC Light-heavyweight M3
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgvf_x6r3_b3239:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_x6r3_a1_gmc02:
+        Description: ''
+        States:
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_x6r3_b3241a:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 128
+          name: ''
+      sgvf_x6r3_b3253:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_x6r3_a1_aud02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+  ex5/01_xkt_x6/rad/x6r4/level/x6r4:
+    Name: AAC Light-heavyweight M4
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_x6r4_a1_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+        - id: 8192
+          name: ''
+        - id: 16384
+          name: ''
+      sgbg_x6r4_a1_gmc03:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+      sgvf_x6r4_b3137:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgbg_x6r4_a1_gmc06:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 32768
+          name: ''
+      sgvf_x6r4_b3139:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_x6r4_a1_gmc07:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 16384
+          name: ''
+        - id: 32768
+          name: ''
+  ex5/01_xkt_x6/rad/x6r5/level/x6r5:
+    Name: AAC Cruiserweight M1
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgvf_x6r5_b3396:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_x6r5_a1_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+      sgbg_x6r5_a1_gmc09:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_x6r5_b3388:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 128
+          name: ''
+      sgvf_x6r5_b3389a:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+        - id: 8192
+          name: ''
+        - id: 16384
+          name: ''
+        - id: 32768
+          name: ''
+      sgvf_x6r5_b3389b:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+        - id: 8192
+          name: ''
+        - id: 16384
+          name: ''
+      sgbg_x6r5_a1_gmc05:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 128
+          name: ''
+      sgvf_x6r5_b3391:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 128
+          name: ''
+      sgvf_x6r5_b3395:
+        Description: ''
+        States:
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+  ex5/01_xkt_x6/rad/x6r6/level/x6r6:
+    Name: AAC Cruiserweight M2
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgvf_x6r6_b3528:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_x6r6_a1_gmc02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+      sgbg_x6r6_a1_gmc03:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+      sgbg_x6r6_a1_gmc06:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 2048
+          name: ''
+      sgbg_x6r6_a1_gmc07:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 2048
+          name: ''
+      sgbg_x6r6_a1_gmc08:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_x6r6_a1_gmc09:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 32
+          name: ''
+      sgvf_x6r6_b3530:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgvf_x6r6_b3531:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgbg_x6r6_a1_gmc17:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_x6r6_b3547:
+        Description: ''
+        States:
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+  ex5/01_xkt_x6/rad/x6r7/level/x6r7:
+    Name: AAC Cruiserweight M3
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_x6r7_a1_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_x6r7_a1_gmc02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_x6r7_a1_gmc03:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_x6r7_a1_gmc04:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_x6r7_a1_gmc05:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_x6r7_a1_gmc07:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgbg_x6r7_a1_gmc06:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgbg_x6r7_a1_gmc08:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_x6r7_a1_gmc09:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+  ex5/01_xkt_x6/rad/x6r8/level/x6r8:
+    Name: AAC Cruiserweight M4
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgvf_x6r8_b3379:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgvf_x6r8_b3379b:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_x6r8_b3357:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_x6r8_a1_gmc11:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgbg_x6r8_a1_gmc13:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_x6r8_a1_gmc04:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 128
+          name: ''
+  ex5/01_xkt_x6/rad/x6r9/level/x6r9:
+    Name: AAC Heavyweight M1
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_x6r9_a1_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_x6r9_a1_gmc07:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+      sgbg_x6r9_a1_gmc03:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+        - id: 8192
+          name: ''
+        - id: 16384
+          name: ''
+        - id: 32768
+          name: ''
+      sgbg_x6r9_a1_gmc08:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+      sgvf_x6r9_b4016:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_x6r9_b4023:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_x6r9_b4018:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+  ex5/01_xkt_x6/rad/x6ra/level/x6ra:
+    Name: AAC Heavyweight M2
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_x6ra_a1_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+      sgvf_x6ra_b4151:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+      sgvf_x6ra_b4032:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+      sgvf_x6ra_b4034a:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+      sgvf_x6ra_b4035a:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+      sgvf_x6ra_b4034b:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+      sgvf_x6ra_b4035b:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+      sgvf_x6ra_b4034c:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+      sgvf_x6ra_b4035c:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+      sgvf_x6ra_b4034d:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+      sgvf_x6ra_b4035d:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+      sgvf_x6ra_b4036:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+        - id: 8192
+          name: ''
+  ex5/01_xkt_x6/rad/x6rb/level/x6rb:
+    Name: AAC Heavyweight M3
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_x6rb_a1_gmc02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 512
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+        - id: 16384
+          name: ''
+      sgvf_x6rb_b3772:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgvf_x6rb_b3777:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgbg_x6rb_a1_gmc03:
+        Description: ''
+        States:
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgvf_x6rb_b3775:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 256
+          name: ''
+  ex5/01_xkt_x6/rad/x6rc/level/x6rc:
+    Name: AAC Heavyweight M4
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_x6rc_a1_gmc02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+        - id: 8192
+          name: ''
+        - id: 16384
+          name: ''
+        - id: 32768
+          name: ''
+      sgbg_x6rc_a1_gmc04:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+        - id: 8192
+          name: ''
+        - id: 32768
+          name: ''
+      sgbg_x6rc_a1_gmc13:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_x6rc_a1_gmc14:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_x6rc_a1_gmc12:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 4
+          name: ''
+  ex5/01_xkt_x6/twn/x6t1/level/x6t1:
+    Name: The Protector and the Destroyer
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgvf_w_lvd_b1199a:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_x6t1_q1_ent01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_x6t1_q1_flor2:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgvf_x6t1_b3147:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+  ex5/02_ykt_y6/dun/y6d1/level/y6d1:
+    Name: Ihuykatumu
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_y6d1_b1_gmc05:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgbg_y6d1_a1_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgbg_y6d1_a1_gmc02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgbg_y6d1_a1_gmc03:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 128
+          name: ''
+      sgbg_y6d1_a2_gmc05:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 16
+          name: ''
+      sgbg_y6d1_a3_gmc06:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 16
+          name: ''
+      sgbg_y6d1_a1_gmc07:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgvf_w_lvd_b2922:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+  ex5/02_ykt_y6/dun/y6d2/level/y6d2:
+    Name: Worqor Zormor
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_y6d2_a1_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_y6d2_a2_gmc02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_y6d2_a2_gmc05:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_y6d2_a3_gmc06:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_y6d2_a2_gmc03:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgvf_y6d2_b3117:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgvf_y6d2_b3118:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgvf_y6d2_b3121:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_y6d2_b3124:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_y6d2_b3_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_y6d2_b3_gmc02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_y6d2_b3_gmc03:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_y6d2_b2_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+      sgbg_y6d2_b2_gmc02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+  ex5/02_ykt_y6/dun/y6d3/level/y6d3:
+    Name: the Skydeep Cenote
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_y6d3_a1_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_y6d3_a1_gmc02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_y6d3_a2_gmc03:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_y6d3_a2_gmc04:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_y6d3_a2_gmc06:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_y6d3_a2_gmc05:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_y6d3_a2_gmc07:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgbg_y6d3_a2_gmc08:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+      sgbg_y6d3_a3_gmc09:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_y6d3_a3_gmc11:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 16
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+      sgbg_y6d3_b3_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+        - id: 16384
+          name: ''
+      sgvf_y6d3_b2878:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_y6d3_b3166:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_y6d3_b2_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 512
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 8192
+          name: ''
+      sgbg_y6d3_b2_gmc02:
+        Description: ''
+        States:
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 128
+          name: ''
+      sgpl_y6d3_p2gmk2:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 4
+          name: ''
+      sgpl_y6d3_p2gmk1:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 4
+          name: ''
+  ex5/02_ykt_y6/evt/y6e1/level/y6e1:
+    Name: A Father First
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgvf_y6e1_b3122:
+        Description: ''
+        States:
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+  ex5/02_ykt_y6/fld/y6f3/level/y6f3:
+    Name: Taking a Stand
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgvf_y6f3_b3176:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+  ex5/02_ykt_y6/fld/y6fa/level/y6fa:
+    Name: Worqor Lar Dor
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_y6fa_a0_gmc03:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_y6fa_a0_gmc02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_y6fa_a0_gmc05:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+      sgbg_y6fa_a0_gmc1a:
+        Description: ''
+        States:
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_y6fa_a0_gmc1b:
+        Description: ''
+        States:
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_y6fa_a0_gmc1c:
+        Description: ''
+        States:
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_y6fa_a0_gmc1d:
+        Description: ''
+        States:
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_y6fa_a0_gmc1e:
+        Description: ''
+        States:
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_y6fa_a0_gmc1f:
+        Description: ''
+        States:
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_y6fa_a0_gmc1g:
+        Description: ''
+        States:
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_y6fa_a0_gmc1h:
+        Description: ''
+        States:
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_y6fa_a0_gmc1i:
+        Description: ''
+        States:
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_y6fa_a0_gmc1j:
+        Description: ''
+        States:
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+  ex5/05_zon_z6/rad/z6r1/level/z6r1:
+    Name: 'Jeuno: The First Walk'
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgvf_z6r1_b3267:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_z6r1_a1_gmc03:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+      sgbg_z6r1_a1_gmc02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+      sgvf_z6r1_b3381:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_z6r1_a0_gmc09:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgvf_z6r1_b3401:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 32
+          name: ''
+      sgbg_z6r1_a0_gmc08:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_z6r1_a0_gmc06:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_z6r1_a0_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_z6r1_a0_gmc05:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 32
+          name: ''
+      sgbg_z6r1_a0_gmc07:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 32
+          name: ''
+      sgvf_z6r1_b3402:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgvf_z6r1_b3356:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_z6r1_b3372:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_z6r1_b3373:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgbg_z6r1_a4_gmc07:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_z6r1_a4_gmc08:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_z6r1_a4_gmc03:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgbg_z6r1_a4_gmc04:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgbg_z6r1_a4_gmc05:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgbg_z6r1_a4_gmc06:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgvf_z6r1_b3293:
+        Description: ''
+        States:
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+  ex5/05_zon_z6/rad/z6r2/level/z6r2:
+    Name: "San d'Oria: The Second Walk"
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_z6r2_a3_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 512
+          name: ''
+      sgbg_z6r2_a3_gmc02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+      sgbg_z6r2_a3_gmc09:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 4
+          name: ''
+      sgvf_z6r2_b3486:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 32
+          name: ''
+      sgbg_z6r2_a0_gmc13:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgvf_z6r1_b3401:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 32
+          name: ''
+      sgvf_z6r1_b3402:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgvf_z6r2_b3464:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_z6r2_b3460:
+        Description: ''
+        States:
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_z6r2_a0_gmc15:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_z6r1_a0_gmc09:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_z6r2_a2_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_z6r2_b3481:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+      sgbg_z6r2_a2_gmc09:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_z6r2_a4_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+        - id: 8192
+          name: ''
+        - id: 16384
+          name: ''
+      sgbg_z6r2_a4_gmc02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+        - id: 8192
+          name: ''
+        - id: 16384
+          name: ''
+      sgbg_z6r2_a4_gmc06:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_z6r2_a4_gmc05:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+      sgbg_z6r2_a2_gmc10:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_z6r2_a2_gmc11:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_z6r2_a0_gmc02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_z6r2_a0_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_z6r2_a0_gmc04:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgvf_z6r2_b3458:
+        Description: ''
+        States:
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgvf_z6r2_b3760:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+      sgvf_z6r2_b3761:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+      sgbg_z6r2_a1_gmc02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+      sgbg_z6r2_a1_gmc06:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgbg_z6r2_a0_gmc03:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_z6r2_a0_gmc07:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+        - id: 8192
+          name: ''
+      sgvf_z6r2_b3465:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_z6r2_b3469:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_z6r2_b3467:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_z6r2_b3468:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_z6r2_b3471:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 128
+          name: ''
+      sgvf_z6r2_b3472:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 128
+          name: ''
+      sgvf_z6r2_b3473:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+      sgbg_z6r2_a0_gmc09:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_z6r1_a0_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgvf_z6r2_b3819:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgvf_z6r2_b3485:
+        Description: ''
+        States:
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgvf_z6r2_b3488:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_z6r2_b3489:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+  ex5/05_zon_z6/rad/z6r3/level/z6r3:
+    Name: 'Windurst: The Third Walk'
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_z6r3_a4_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+        - id: 8192
+          name: ''
+        - id: 16384
+          name: ''
+      sgbg_z6r3_a4_gmc02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_z6r3_a4_gmc03:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 4
+          name: ''
+      sgvf_z6r3_b4003:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_z6r3_b3847:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+      sgvf_z6r1_b3402:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgvf_z6r1_b3402a:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_z6r3_a2_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_z6r3_b4308:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_z6r3_b4310:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_z6r3_b0_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgbg_z6r3_a3_gmc04:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgvf_z6r3_b3494a:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_z6r3_a2_gmc03:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+      sgvf_z6r3_b4311:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_z6r3_b4312:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+      sgvf_z6r3_b4315:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_z6r3_a1_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+      sgbg_z6r3_a1_gmc06:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+      sgbg_z6r3_a1_gmc07:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+      sgbg_z6r3_a0_gmc02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_z6r3_a0_gmc04:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_z6r3_b4300:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_z6r1_a0_gmc09:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgvf_z6r3_b4176:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+      sgvf_z6r3_b4177:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_z6r3_b0_gmc04:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_z6r3_b0_gmc05:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 4
+          name: ''
+  ex5/06_nvt_n6/cnt/n6c1/level/n6c1:
+    Name: Pilgrim's Traverse (Stones 1-10)
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgvf_n6c1_b3396:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+  ex5/06_nvt_n6/cnt/n6c2/level/n6c2:
+    Name: Pilgrim's Traverse (Stones 11-20)
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgvf_n6c2_b3446:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+  ex5/06_nvt_n6/cnt/n6c3/level/n6c3:
+    Name: Pilgrim's Traverse (Stones 21-30)
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_n6c3_b1_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+  ex5/06_nvt_n6/cnt/n6c4/level/n6c4:
+    Name: Pilgrim's Traverse (Stones 41-50)
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgvf_n6c4_b3854:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgvf_n6c4_b3855:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+  ex5/06_nvt_n6/cnt/n6c5/level/n6c5:
+    Name: Pilgrim's Traverse (Stones 61-70)
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgvf_n6c5_b3852:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+  ex5/06_nvt_n6/cnt/n6c6/level/n6c6:
+    Name: Pilgrim's Traverse (Stones 81-90)
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgvf_n6c6_b3853:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+  ex5/07_mid_m6/dun/m6d1/level/m6d1:
+    Name: The Merchant's Tale
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_m6d1_b2_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_m6d1_b1_gmc04:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_m6d1_b1_gmc09:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_m6d1_a0_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_m6d1_a1_gmc24:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_m6d1_a1_gmc03:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_m6d1_a0_gmc02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_m6d1_a1_gmc05:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_m6d1_a1_gmc25:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgbg_m6d1_a1_gmc07:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_m6d1_a1_gmc08:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_m6d1_a1_gmc06:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_m6d1_a1_gmc04:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_m6d1_a3_gmc16:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_m6d1_a3_gmc15:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_m6d1_a3_gmc17:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_m6d1_a3_gmc21:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_m6d1_a3_gmc22:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_m6d1_a3_gmc20:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+      sgbg_m6d1_a3_gmc18:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_m6d1_a2_gmc09:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_m6d1_a2_gmc10:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_m6d1_a2_gmc12:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_m6d1_a2_gmc11:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_m6d1_a2_gmc30:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_m6d1_a2_gmc14:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_m6d1_b4200:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 32
+          name: ''
+      sgvf_m6d1_b4201:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 32
+          name: ''
+      sgvf_m6d1_b4202:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 32
+          name: ''
+      sgvf_m6d1_b4203:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 32
+          name: ''
+      sgvf_m6d1_b4204:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 32
+          name: ''
+      sgbg_m6d1_a4_gmc23:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 32768
+          name: ''
+      sgbg_m6d1_a1_gmc26:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_m6d1_a2_gmc27:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_m6d1_a3_gmc28:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgvf_w_lvd_b2935:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+  ex5/07_mid_m6/dun/m6d2/level/m6d2:
+    Name: the Clyteum
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_m6d2_a1_gmc03:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_m6d2_a2_gmc04:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_m6d2_a1_gmc02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_m6d2_a1_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_m6d2_a2_gmc05:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_m6d2_a3_gmc06:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_m6d2_a3_gmc07:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_m6d2_a3_gmc08:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_m6d2_a1_gmc09:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgvf_m6d2_b3971:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_m6d2_b3970:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_m6d2_b3972:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+  ffxiv/fst_f1/dun/f1db/level/f1db:
+    Name: The Phantoms' Feast
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgvf_f1db_b2250:
+        Description: ''
+        States:
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+  ffxiv/fst_f1/dun/f1dc/level/f1dc:
+    Name: Mind over Manor
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_f1dc_a1_door1:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+  ffxiv/fst_f1/dun/f1dd/level/f1dd:
+    Name: the Pâtisserie
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgvf_f1dd_b3397:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgvf_f1b1_b3398:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_f1dd_c1_crem1:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+        - id: 8192
+          name: ''
+      sgbg_f1dd_c1_crem2:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+        - id: 8192
+          name: ''
+      sgbg_f1dd_c1_crem3:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+        - id: 8192
+          name: ''
+      sgbg_f1dd_c1_crem4:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+        - id: 8192
+          name: ''
+      sgbg_f1dd_c1_frut1:
+        Description: ''
+        States:
+        - id: 4
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+        - id: 8192
+          name: ''
+      sgbg_f1dd_c2_frut1:
+        Description: ''
+        States:
+        - id: 4
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+        - id: 8192
+          name: ''
+      sgbg_f1dd_c3_frut1:
+        Description: ''
+        States:
+        - id: 4
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+        - id: 8192
+          name: ''
+      sgbg_f1dd_c4_frut1:
+        Description: ''
+        States:
+        - id: 4
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+        - id: 8192
+          name: ''
+      sgbg_f1dd_c1_swet1:
+        Description: ''
+        States:
+        - id: 4
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+        - id: 8192
+          name: ''
+      sgbg_f1dd_c2_swet1:
+        Description: ''
+        States:
+        - id: 4
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+        - id: 8192
+          name: ''
+      sgbg_f1dd_c3_swet1:
+        Description: ''
+        States:
+        - id: 4
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+        - id: 8192
+          name: ''
+      sgbg_f1dd_c4_swet1:
+        Description: ''
+        States:
+        - id: 4
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+        - id: 8192
+          name: ''
+      sgbg_f1dd_c1_deco1:
+        Description: ''
+        States:
+        - id: 4
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+        - id: 8192
+          name: ''
+      sgbg_f1dd_c2_deco1:
+        Description: ''
+        States:
+        - id: 4
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+        - id: 8192
+          name: ''
+      sgbg_f1dd_c3_deco1:
+        Description: ''
+        States:
+        - id: 4
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+        - id: 8192
+          name: ''
+      sgbg_f1dd_c4_deco1:
+        Description: ''
+        States:
+        - id: 4
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+        - id: 8192
+          name: ''
+      sgvf_f1dd_b3399:
+        Description: ''
+        States:
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_f1dd_b0838a:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+  ffxiv/fst_f1/fld/f1f1/level/f1f1:
+    Name: A Path Unveiled
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgvf_f1f1_b2394:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_f1f1_b2395:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+  ffxiv/fst_f1/fld/f1fa/level/f1fa:
+    Name: Thornmarch (Hard)
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_f1fa_mogmete01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgvf_w_btl_b1922:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+  ffxiv/fst_f1/rad/f1r1/level/f1r1:
+    Name: the Thousand Maws of Toto-Rak
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_f1r1_dor04:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+  ffxiv/lak_l1/pvp/l1p1/level/l1p1:
+    Name: Death Unto Dawn
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgvf_w_lvd_b1199a:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_l1p1_b1777b:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_l1p1_b1771:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_l1p1_b1778:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_l1p1_b1777:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+  ffxiv/lak_l1/rad/l1rz/level/l1rz:
+    Name: the Cloud of Darkness (Chaotic)
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgvf_l1rz_b3263:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgvf_l1rz_b3261:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_l1rz_b3262:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_l1rz_a2_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 512
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 8192
+          name: ''
+      sgvf_l1rz_b3258a:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 2048
+          name: ''
+      sgvf_l1rz_b3258b:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 2048
+          name: ''
+      sgvf_l1rz_b3258c:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 2048
+          name: ''
+      sgvf_l1rz_b3257a:
+        Description: ''
+        States:
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_l1rz_b3257b:
+        Description: ''
+        States:
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_l1rz_b3257c:
+        Description: ''
+        States:
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_l1rz_a2_gmc02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+  ffxiv/ocn_o1/ang/o1a1/level/o1a1:
+    Name: Ocean Fishing
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgvf_o1a1_b1763:
+        Description: ''
+        States:
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgvf_o1a1_se001:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+  ffxiv/ocn_o1/ang/o1a2/level/o1a2:
+    Name: Ocean Fishing
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgvf_o1a1_b1763:
+        Description: ''
+        States:
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgvf_o1a1_se001:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+  ffxiv/roc_r1/fld/r1fd/level/r1fd:
+    Name: the Steps of Faith
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_r1fd_b1_barr1:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+      sgvf_w_lvd_b2756:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgpl_r1fd_a0_se001:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+  ffxiv/roc_r1/fld/r1fz/level/r1fz:
+    Name: Dragonsong's Reprise (Ultimate)
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_r1fz_a2_gimk2:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+      sgbg_r1fz_e0_hreas01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+  ffxiv/sea_s1/dun/s1d2/level/s1d2:
+    Name: Brayflox's Longstop
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_s1d2_a0_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_s1d6_door2:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+  ffxiv/sea_s1/dun/s1d6/level/s1d6:
+    Name: Brayflox's Longstop (Hard)
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_s1d6_door2:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+  ffxiv/sea_s1/dun/s1d7/level/s1d7:
+    Name: Sastasha (Hard)
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_s1d7_w1_lake0:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+  ffxiv/sea_s1/pvp/s1p6/level/s1p6:
+    Name: React to Attack Markers
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgvf_w_lvd_b3265:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+  ffxiv/wil_w1/dun/w1d2/level/w1d2:
+    Name: Halatali
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_w1d2_a1_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_w1d2_a2_gmc02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+  ffxiv/wil_w1/dun/w1d3/level/w1d3:
+    Name: the Sunken Temple of Qarn
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_w_qic_004_05b:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+  ffxiv/wil_w1/dun/w1d4/level/w1d4:
+    Name: Castrum Meridianum
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_w1d4_a0_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+      sgbg_w_emp_015_01a:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_w1d4_a0_gmc02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_w1d4_a0_gmc03:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_w1d4_a0_gmc04:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_w1d4_a0_gmc05:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_w1d4_b2541:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+  ffxiv/wil_w1/dun/w1d5/level/w1d5:
+    Name: the Praetorium
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgvf_w_btl_b0216a:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_w1d5_a0_gmc02:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_w1d5_a0_gmc03:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_w1d5_a0_gmc04:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_w1d5_a0_gmc05:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_w1d5_a0_gmc06:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_w1d5_q5_doa01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgbg_w1d5_q5_gate1:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_w1d5_a0_gmc07:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_w1d5_a0_gmc08:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_w1d5_q6_lift2:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+        - id: 4096
+          name: ''
+        - id: 8192
+          name: ''
+      sgbg_w1d5_q6_lift3:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+      sgbg_w1d4_a0_gmc01:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+  ffxiv/wil_w1/fld/w1f1/level/w1f1:
+    Name: Cape Westwind
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgvf_w1f1_b2535:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 64
+          name: ''
+        - id: 128
+          name: ''
+        - id: 256
+          name: ''
+        - id: 512
+          name: ''
+        - id: 1024
+          name: ''
+        - id: 2048
+          name: ''
+      sgvf_w_evt_b2185a:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_w_lvd_b2534:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+  ffxiv/wil_w1/fld/w1fd/level/w1fd:
+    Name: Memory of Embers
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgvf_w1fd_b2808:
+        Description: ''
+        States:
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+      sgvf_w1fd_b2809:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+        - id: 16
+          name: ''
+        - id: 32
+          name: ''
+        - id: 128
+          name: ''
+      sgvf_w1fd_b2821:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''
+  ffxiv/wil_w1/rad/w1r1/level/w1r1:
+    Name: The Harvest Begins
+    Spawn:
+      X: 0
+      Y: 0
+      Z: 0
+    MapEffects:
+      sgbg_w_qic_004_03b:
+        Description: ''
+        States:
+        - id: 1
+          name: ''
+        - id: 2
+          name: ''
+        - id: 4
+          name: ''
+        - id: 8
+          name: ''


### PR DESCRIPTION
Just replacing the number based mapeffects to the actually possible slots and states to pick from a dropdown.

TimelineOverride (a3) is now hidden behind the gear icon in the editor window after each slot and state as I had no way to verify that in live instances as it seems like it just sets bits in the same bitfield as state.

For all my tested cases, if the bit for timelineOverride was higher than the state, that one took over for the displayed mapeffect. So timelineOverride need a lot more testing to check what really changes.

Also the commit name to keep the meme up for shits and giggles x)